### PR TITLE
Refactor StructPerm

### DIFF
--- a/ConNF/Atom/Litter.lean
+++ b/ConNF/Atom/Litter.lean
@@ -1,4 +1,3 @@
-import Mathlib.Data.Prod.Lex
 import ConNF.Atom.Params
 
 /-!
@@ -36,7 +35,7 @@ noncomputable instance : Inhabited Litter :=
   ⟨⟨default, ⊥, default, WithBot.bot_ne_coe⟩⟩
 
 /-- Litters are equivalent to a subtype of a product type. -/
-def litterEquiv : Litter ≃ { a : μ ×ₗ TypeIndex ×ₗ Λ // a.2.1 ≠ a.2.2 }
+def litterEquiv : Litter ≃ { a : μ × TypeIndex × Λ // a.2.1 ≠ a.2.2 }
     where
   toFun L := ⟨⟨L.ν, L.β, L.γ⟩, L.β_ne_γ⟩
   invFun L := ⟨L.val.1, L.val.2.1, L.val.2.2, L.prop⟩
@@ -52,7 +51,7 @@ theorem mk_litter : #Litter = #μ := by
             congr_arg <| Prod.fst ∘ Subtype.val⟩⟩)
   have :=
     mul_eq_left (κ_regular.aleph0_le.trans κ_le_μ) (Λ_lt_κ.le.trans κ_lt_μ.le) Λ_limit.ne_zero
-  simp only [Lex, mk_prod, lift_id, mk_typeIndex, mul_eq_self Λ_limit.aleph0_le, this]
+  simp only [mk_prod, lift_id, mk_typeIndex, mul_eq_self Λ_limit.aleph0_le, this]
 
 /-- Principal segments (sets of the form `{y | y < x}`) have cardinality `< μ`. -/
 theorem card_Iio_lt (x : μ) : #(Iio x) < #μ :=

--- a/ConNF/Atom/NearLitterPerm.lean
+++ b/ConNF/Atom/NearLitterPerm.lean
@@ -189,32 +189,35 @@ instance : MulAction NearLitterPerm Litter
   one_smul _ := rfl
   mul_smul _ _ _ := rfl
 
-theorem near_smul (f : NearLitterPerm) (h : IsNearLitter i s) : IsNearLitter (f • i) (f • s) := by
-  convert f.near h using 1
-  exact (preimage_inv _ _).symm
-
-instance : SMul NearLitterPerm NearLitter :=
-  ⟨fun f N => ⟨f • N.1, f • (N : Set Atom), f.near_smul N.2.2⟩⟩
-
-@[simp]
-theorem toProd_smul (f : NearLitterPerm) (N : NearLitter) : (f • N).toProd = f • N.toProd :=
-  rfl
-
 /-- Near-litter permutations act on near-litters. -/
-instance : MulAction NearLitterPerm NearLitter :=
-  NearLitter.toProd_injective.mulAction _ toProd_smul
+instance : MulAction NearLitterPerm NearLitter
+    where
+  smul f N := ⟨f • N.1, ↑f.atomPerm⁻¹ ⁻¹' N, f.near N.2.2⟩
+  one_smul _ := rfl
+  mul_smul _ _ _ := rfl
 
 @[simp]
-theorem smul_fst (π : NearLitterPerm) (N : NearLitter) : (π • N).fst = π • N.fst :=
+theorem smul_nearLitter_fst (π : NearLitterPerm) (N : NearLitter) : (π • N).fst = π • N.fst :=
   rfl
 
-@[simp]
-theorem coe_smul (π : NearLitterPerm) (N : NearLitter) : ((π • N) : Set Atom) = π • (N : Set Atom) :=
+theorem smul_nearLitter_coe_preimage (π : NearLitterPerm) (N : NearLitter) :
+    π • N = ↑π.atomPerm⁻¹ ⁻¹' N :=
   rfl
+
+theorem smul_nearLitter_coe (π : NearLitterPerm) (N : NearLitter) :
+    ((π • N) : Set Atom) = π • (N : Set Atom) := by
+  rw [smul_nearLitter_coe_preimage, preimage_inv]
+  rfl
+
+theorem smul_nearLitter_snd (π : NearLitterPerm) (N : NearLitter) :
+    ((π • N).2 : Set Atom) = π • (N.2 : Set Atom) :=
+  smul_nearLitter_coe π N
 
 @[simp]
 theorem smul_localCardinal (π : NearLitterPerm) (i : Litter) :
-    π • localCardinal i = localCardinal (π • i) := by ext N; simp [mem_smul_set, ← eq_inv_smul_iff]
+    π • localCardinal i = localCardinal (π • i) := by
+  ext N
+  simp [mem_smul_set, ← eq_inv_smul_iff]
 
 @[simp]
 theorem NearLitter.mem_snd_iff (N : NearLitter) (a : Atom) : a ∈ (N.snd : Set Atom) ↔ a ∈ N :=
@@ -227,7 +230,7 @@ theorem NearLitter.not_mem_snd_iff (N : NearLitter) (a : Atom) : a ∉ (N.snd : 
 theorem smul_nearLitter_eq_smul_symmDiff_smul (π : NearLitterPerm) (N : NearLitter) :
     (π • N : Set Atom) = (π • N.fst.toNearLitter : Set Atom) ∆ (π • litterSet N.fst ∆ N.snd) := by
   ext a : 1
-  simp only [mem_symmDiff, mem_smul_set_iff_inv_smul_mem, coe_smul]
+  simp only [mem_symmDiff, mem_smul_set_iff_inv_smul_mem, smul_nearLitter_coe]
   tauto
 
 end NearLitterPerm

--- a/ConNF/Foa/Action/NearLitterAction.lean
+++ b/ConNF/Foa/Action/NearLitterAction.lean
@@ -498,7 +498,7 @@ theorem smul_toNearLitter_eq_of_preciseAt {hφ : φ.Lawful} {π : NearLitterPerm
     π • L.toNearLitter = (φ.litterMap L).get hL := by
   refine' SetLike.coe_injective _
   ext a : 1
-  simp only [mem_smul_set_iff_inv_smul_mem, NearLitterPerm.coe_smul, Litter.coe_toNearLitter,
+  simp only [mem_smul_set_iff_inv_smul_mem, NearLitterPerm.smul_nearLitter_coe, Litter.coe_toNearLitter,
     mem_litterSet, SetLike.mem_coe]
   constructor
   · intro ha

--- a/ConNF/Foa/Basic/Approximation.lean
+++ b/ConNF/Foa/Basic/Approximation.lean
@@ -311,7 +311,7 @@ theorem ExactlyApproximates.map_nearLitter {π₀ : NearLitterApprox} {π : Near
   rw [smul_nearLitter_coe]
   ext a : 1
   simp only [coe_largestSublitter, mem_union, mem_diff, ConNF.mem_litterSet,
-    NearLitterPerm.coe_smul]
+    NearLitterPerm.smul_nearLitter_coe]
   constructor
   · rintro (⟨ha₁, ha₂⟩ | ⟨b, ⟨hb₁, hb₂⟩, rfl⟩)
     · rw [hπ.map_litter _ h₁, ← inv_smul_eq_iff] at ha₁

--- a/ConNF/Foa/Basic/Hypotheses.lean
+++ b/ConNF/Foa/Basic/Hypotheses.lean
@@ -90,13 +90,15 @@ class Phase2Assumptions extends Phase2Data α where
     π • (designatedSupport t : Set (SupportCondition β)) = designatedSupport (π • t)
   smul_fuzz {β : IicBot α} (γ : IioBot α) (δ : Iio α) (hγ : (γ : TypeIndex) < β)
     (hδ : (δ : TypeIndex) < β) (hγδ : γ ≠ δ) (π : Allowable β) (t : Tangle γ) :
-    allowableDerivative β δ hδ π • fuzz (Subtype.coe_injective.ne hγδ) t =
-      fuzz (Subtype.coe_injective.ne hγδ) (allowableDerivative β γ hγ π • t)
+    NearLitterPerm.ofBot (allowableDerivative δ ⊥ (bot_lt_coe _) (allowableDerivative β δ hδ π)) •
+      fuzz (Subtype.coe_injective.ne hγδ) t =
+    fuzz (Subtype.coe_injective.ne hγδ) (allowableDerivative β γ hγ π • t)
   allowableOfSmulFuzz (β : Iic α) (πs : ∀ γ : IioBot α, (γ : TypeIndex) < β → Allowable γ) :
     (∀ (γ : IioBot α) (δ : Iio α) (hγ : (γ : TypeIndex) < β) (hδ : (δ : TypeIndex) < β)
         (hγδ : γ ≠ δ) (t : Tangle γ),
-        πs δ hδ • fuzz (Subtype.coe_injective.ne hγδ) t =
-          fuzz (Subtype.coe_injective.ne hγδ) (πs γ hγ • t)) →
+        NearLitterPerm.ofBot (allowableDerivative δ ⊥ (bot_lt_coe _) (πs δ hδ)) •
+          fuzz (Subtype.coe_injective.ne hγδ) t =
+        fuzz (Subtype.coe_injective.ne hγδ) (πs γ hγ • t)) →
       Allowable (β : IicBot α)
   allowableOfSmulFuzz_derivative_eq {β : Iic α} {πs} {h} (γ : IioBot α)
     (hγ : (γ : TypeIndex) < β) :
@@ -118,34 +120,34 @@ theorem Allowable.derivative_nil {β : IicBot α} :
   rfl
 
 @[simp]
+theorem Allowable.derivative_eq {β γ : IicBot α} (h : γ < β) :
+    allowableDerivative β γ h = Allowable.derivative (Quiver.Path.nil.cons h) :=
+  rfl
+
 theorem Allowable.derivative_cons {β γ δ : IicBot α} (A : Quiver.Path (β : TypeIndex) γ)
     (h : δ < γ) :
-    Allowable.derivative (A.cons h) = (allowableDerivative γ δ h).comp (Allowable.derivative A) :=
+    (allowableDerivative γ δ h).comp (Allowable.derivative A) = Allowable.derivative (A.cons h) :=
   rfl
 
 theorem Allowable.derivative_cons_apply (β γ δ : IicBot α) (A : Quiver.Path (β : TypeIndex) γ)
     (h : δ < γ) (π : Allowable β) :
-    Allowable.derivative (A.cons h) π = allowableDerivative γ δ h (Allowable.derivative A π) :=
+    allowableDerivative γ δ h (Allowable.derivative A π) = Allowable.derivative (A.cons h) π :=
   rfl
 
 theorem Allowable.derivative_cons_apply' (β : Iio α) (γ : Iic α) (δ : Iio α)
     (A : Quiver.Path (β : TypeIndex) γ) (h : (δ : TypeIndex) < γ) (π : Allowable β) :
-    @Allowable.derivative _ _ _ _ (β : IicBot α) (δ : IicBot α) (A.cons h) π =
-      allowableDerivative (γ : IicBot α) (δ : IicBot α) h
-        (Allowable.derivative
-          (show Quiver.Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from A) π) :=
+    allowableDerivative (γ : IicBot α) (δ : IicBot α) h
+      (Allowable.derivative
+        (show Quiver.Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from A) π) =
+    @Allowable.derivative _ _ _ _ (β : IicBot α) (δ : IicBot α) (A.cons h) π :=
   rfl
 
 theorem Allowable.derivative_cons_apply'' (β : Iio α) (γ : Iic α)
     (A : Quiver.Path (β : TypeIndex) γ) (π : Allowable β) :
-    @Allowable.derivative _ _ _ _ (β : IicBot α) (⊥ : IicBot α) (A.cons <| bot_lt_coe _) π =
-      allowableDerivative (γ : IicBot α) (⊥ : IicBot α) (bot_lt_coe _)
-        (Allowable.derivative
-          (show Quiver.Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from A) π) :=
-  rfl
-
-theorem Allowable.derivative_eq {β γ : IicBot α} (h : γ < β) :
-    allowableDerivative β γ h = Allowable.derivative (Quiver.Path.nil.cons h) :=
+    allowableDerivative (γ : IicBot α) (⊥ : IicBot α) (bot_lt_coe _)
+      (Allowable.derivative
+        (show Quiver.Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from A) π) =
+    @Allowable.derivative _ _ _ _ (β : IicBot α) (⊥ : IicBot α) (A.cons <| bot_lt_coe _) π :=
   rfl
 
 theorem Allowable.derivative_derivative {β γ δ : IicBot α} (A : Quiver.Path (β : TypeIndex) γ)
@@ -158,53 +160,31 @@ theorem Allowable.derivative_derivative {β γ δ : IicBot α} (A : Quiver.Path 
   | nil => simp only [Quiver.Path.comp_nil, Allowable.derivative_nil, MonoidHom.id_apply]
   | cons B H ih =>
     rw [Quiver.Path.comp_cons]
-    rw [Allowable.derivative_cons
-        (show
-          Quiver.Path ((⟨γ, hγ⟩ : IicBot α) : TypeIndex)
-            ((⟨_, le_trans (le_of_path B) hγ⟩ : IicBot α) : TypeIndex)
-          from B)]
-    rw [MonoidHom.coe_comp, Function.comp_apply, ih, ← Allowable.derivative_cons_apply]
+    rw [← Allowable.derivative_cons (show Quiver.Path
+      ((⟨γ, hγ⟩ : IicBot α) : TypeIndex)
+      ((⟨_, le_trans (le_of_path B) hγ⟩ : IicBot α) : TypeIndex)
+      from B)]
+    rw [MonoidHom.coe_comp, Function.comp_apply, ih, Allowable.derivative_cons_apply]
 
-theorem Allowable.derivative_toStructPerm {β γ : IicBot α} (A : Quiver.Path (β : TypeIndex) γ)
-    (π : Allowable β) :
-    StructPerm.derivative A (Allowable.toStructPerm π) =
-    Allowable.toStructPerm (Allowable.derivative A π) := by
+@[simp]
+theorem Allowable.toStructPerm_derivative {β γ : IicBot α}
+    (A : Quiver.Path (β : TypeIndex) γ) (π : Allowable β) :
+    Allowable.toStructPerm (Allowable.derivative A π) =
+    StructPerm.derivative A (Allowable.toStructPerm π) := by
   obtain ⟨γ, hγ⟩ := γ
   change Quiver.Path (β : TypeIndex) γ at A
   induction A with
   | nil => rw [StructPerm.derivative_nil, Allowable.derivative_nil, MonoidHom.id_apply]
   | cons A h ih =>
-      change _ = toStructPerm (allowableDerivative _ _ _ (derivative _ π))
+      change toStructPerm (allowableDerivative _ _ _ (derivative _ π)) = _
       rw [StructPerm.derivative_cons, ← allowableDerivative_eq, ih]
-
-theorem Allowable.derivative_smul {β γ : IicBot α} (A : Quiver.Path (β : TypeIndex) γ)
-    (π : Allowable β) {X : Type _} [MulAction (StructPerm γ) X] (x : X) :
-    Allowable.derivative A π • x =
-    StructPerm.derivative A (Allowable.toStructPerm π) • x := by
-  rw [Allowable.derivative_toStructPerm]
-  rfl
-
--- TODO: Unify next three lemmas.
-@[simp]
-theorem Allowable.derivative_bot_smul_atom (β : Iic α) (π : Allowable β) (a : Atom) :
-    allowableDerivative (iicCoe β) ⊥ (bot_lt_coe (β : Λ)) π • a = π • a := by
-  refine Eq.trans ?_ (StructPerm.derivative_bot_smul (Allowable.toStructPerm π) a)
-  have := allowableDerivative_eq (iicCoe β) ⊥ (bot_lt_coe _) π
-  exact congr_arg₂ (· • ·) this.symm rfl
+      rfl
 
 @[simp]
-theorem Allowable.derivative_bot_smul_litter (β : Iic α) (π : Allowable β) (L : Litter) :
-    allowableDerivative (iicCoe β) ⊥ (bot_lt_coe (β : Λ)) π • L = π • L := by
-  refine Eq.trans ?_ (StructPerm.derivative_bot_smul (Allowable.toStructPerm π) L)
-  have := allowableDerivative_eq (iicCoe β) ⊥ (bot_lt_coe _) π
-  exact congr_arg₂ (· • ·) this.symm rfl
-
-@[simp]
-theorem Allowable.derivative_bot_smul_nearLitter (β : Iic α) (π : Allowable β) (N : NearLitter) :
-    allowableDerivative (iicCoe β) ⊥ (bot_lt_coe (β : Λ)) π • N = π • N := by
-  refine Eq.trans ?_ (StructPerm.derivative_bot_smul (Allowable.toStructPerm π) N)
-  have := allowableDerivative_eq (iicCoe β) ⊥ (bot_lt_coe _) π
-  exact congr_arg₂ (· • ·) this.symm rfl
+theorem Allowable.toStructPerm_apply {β : IicBot α}
+    (A : Quiver.Path (β : TypeIndex) (⊥ : IicBot α)) (π : Allowable β) :
+    NearLitterPerm.ofBot (Allowable.derivative A π) = Allowable.toStructPerm π A :=
+  congr_fun (Allowable.toStructPerm_derivative A π) Quiver.Path.nil
 
 theorem smul_mem_designatedSupport {β : Iio α} {c : SupportCondition β} {t : Tangle β}
     (h : c ∈ designatedSupport t) (π : Allowable β) : π • c ∈ designatedSupport (π • t) :=
@@ -212,13 +192,20 @@ theorem smul_mem_designatedSupport {β : Iio α} {c : SupportCondition β} {t : 
         ((show Allowable (β : Iic α) from π) • c)).mp
     ⟨c, h, rfl⟩
 
+@[simp]
+theorem ofBot_derivative {β : IicBot α} {hβ : ⊥ < β} {π : Allowable β} :
+    NearLitterPerm.ofBot (allowableDerivative β ⊥ hβ π) =
+    Allowable.toStructPerm π (Quiver.Hom.toPath hβ) :=
+  (congr_fun (allowableDerivative_eq β ⊥ hβ π) Quiver.Path.nil).symm
+
 theorem toStructPerm_smul_fuzz (β : IicBot α) (γ : IioBot α) (δ : Iio α)
     (hγ : (γ : TypeIndex) < β) (hδ : (δ : TypeIndex) < β) (hγδ : γ ≠ δ) (π : Allowable β)
     (t : Tangle γ) :
-    StructPerm.derivative (Quiver.Path.nil.cons hδ) (Allowable.toStructPerm π) •
-        fuzz (Subtype.coe_injective.ne hγδ) t =
-      fuzz (Subtype.coe_injective.ne hγδ) (allowableDerivative β γ hγ π • t) := by
-  rw [allowableDerivative_eq β δ hδ π]
-  exact smul_fuzz γ δ hγ hδ hγδ π t
+    Allowable.toStructPerm π ((Quiver.Path.nil.cons hδ).cons (bot_lt_coe _)) •
+      fuzz (Subtype.coe_injective.ne hγδ) t =
+    fuzz (Subtype.coe_injective.ne hγδ) (allowableDerivative β γ hγ π • t) := by
+  have := congr_fun (allowableDerivative_eq β δ hδ π) (Quiver.Hom.toPath (bot_lt_coe _))
+  simp only [StructPerm.derivative_apply, Quiver.Hom.comp_toPath] at this
+  rw [this, ← smul_fuzz γ δ hγ hδ hγδ π t, ofBot_derivative]
 
 end ConNF

--- a/ConNF/Foa/Basic/Hypotheses.lean
+++ b/ConNF/Foa/Basic/Hypotheses.lean
@@ -193,10 +193,46 @@ theorem smul_mem_designatedSupport {β : Iio α} {c : SupportCondition β} {t : 
     ⟨c, h, rfl⟩
 
 @[simp]
-theorem ofBot_derivative {β : IicBot α} {hβ : ⊥ < β} {π : Allowable β} :
+theorem ofBot_derivative' {β : IicBot α} {hβ : ⊥ < β} {π : Allowable β} :
     NearLitterPerm.ofBot (allowableDerivative β ⊥ hβ π) =
     Allowable.toStructPerm π (Quiver.Hom.toPath hβ) :=
   (congr_fun (allowableDerivative_eq β ⊥ hβ π) Quiver.Path.nil).symm
+
+theorem exists_cons_of_length_ne_zero {V : Type _} [Quiver V] {x y : V}
+    (p : Quiver.Path x y) (h : p.length ≠ 0) :
+    ∃ t : V, ∃ q : Quiver.Path x t, ∃ e : t ⟶ y, p = q.cons e := by
+  cases p
+  · cases h rfl
+  · exact ⟨_, _, _, rfl⟩
+
+theorem ofBot_derivative {β : IicBot α} {π : Allowable β}
+    (A : Quiver.Path (β : TypeIndex) (⊥ : IicBot α)) :
+    NearLitterPerm.ofBot (Allowable.derivative A π) = Allowable.toStructPerm π A := by
+  dsimp only [Iic.coe_bot] at A
+  by_cases A.length = 0
+  · have : β = ⊥ := Subtype.coe_injective (Quiver.Path.eq_of_length_zero A h)
+    cases this
+    cases path_eq_nil A
+    rfl
+  · obtain ⟨γ, A, h', rfl⟩ := exists_cons_of_length_ne_zero A h
+    have := Allowable.derivative_cons
+      (show Quiver.Path (β : TypeIndex) (⟨γ, ?_⟩ : IicBot α) from A)
+      (show ⊥ < ⟨γ, _⟩ from h')
+    rw [← this, MonoidHom.comp_apply, ofBot_derivative', Allowable.toStructPerm_derivative]
+    simp only [StructPerm.derivative_apply, Quiver.Hom.comp_toPath]
+    exact le_trans (le_of_path A) β.prop
+
+@[simp]
+theorem ofBot_smul {X : Type _} [MulAction NearLitterPerm X] (π : Allowable ⊥) (x : X) :
+    π • x = NearLitterPerm.ofBot π • x :=
+  rfl
+
+@[simp]
+theorem derivative_bot_smul_atom {β : IicBot α}
+    (π : Allowable β) (A : Quiver.Path (β : TypeIndex) (⊥ : IicBot α)) (a : Tangle ⊥) :
+    Allowable.derivative A π • a = Allowable.toStructPerm π A • (show Atom from a) := by
+  rw [← ofBot_derivative]
+  rfl
 
 theorem toStructPerm_smul_fuzz (β : IicBot α) (γ : IioBot α) (δ : Iio α)
     (hγ : (γ : TypeIndex) < β) (hδ : (δ : TypeIndex) < β) (hγδ : γ ≠ δ) (π : Allowable β)
@@ -206,6 +242,6 @@ theorem toStructPerm_smul_fuzz (β : IicBot α) (γ : IioBot α) (δ : Iio α)
     fuzz (Subtype.coe_injective.ne hγδ) (allowableDerivative β γ hγ π • t) := by
   have := congr_fun (allowableDerivative_eq β δ hδ π) (Quiver.Hom.toPath (bot_lt_coe _))
   simp only [StructPerm.derivative_apply, Quiver.Hom.comp_toPath] at this
-  rw [this, ← smul_fuzz γ δ hγ hδ hγδ π t, ofBot_derivative]
+  rw [this, ← smul_fuzz γ δ hγ hδ hγδ π t, ofBot_derivative']
 
 end ConNF

--- a/ConNF/Foa/Complete/CompleteAction.lean
+++ b/ConNF/Foa/Complete/CompleteAction.lean
@@ -124,19 +124,8 @@ theorem completeLitterMap_eq_of_flexible {A : ExtendedIndex β} {L : Litter} (h 
     π.completeLitterMap A L = NearLitterApprox.flexibleCompletion α (π A) A • L := by
   rw [completeLitterMap_eq, litterCompletion_of_flexible _ _ _ _ h]
 
--- TODO: move to StructPerm
-@[simp]
-theorem _root_.ConNF.StructPerm.derivative_fst {α β : TypeIndex} (π : StructPerm α) (A : Path α β)
-    (N : NearLitter) : (StructPerm.derivative A π • N).fst = StructPerm.derivative A π • N.fst :=
-  rfl
-
 theorem toStructPerm_bot :
     (Allowable.toStructPerm : Allowable ⊥ → StructPerm ⊥) = StructPerm.toBotIso.toMonoidHom :=
-  rfl
-
-@[simp]
-theorem toStructPerm_toNearLitterPerm (π : Allowable ⊥) :
-    StructPerm.toNearLitterPerm (Allowable.toStructPerm π) = π := by
   rfl
 
 -- TODO: use this

--- a/ConNF/Foa/Properties/Injective.lean
+++ b/ConNF/Foa/Properties/Injective.lean
@@ -447,8 +447,6 @@ theorem completeLitterMap_inflexibleCoe_iff (hπf : π.Free) {c d : SupportCondi
   ⟨fun ⟨h⟩ => ⟨completeLitterMap_inflexibleCoe' hπf h⟩, fun ⟨h⟩ =>
     ⟨completeLitterMap_inflexibleCoe hπf hcd h hL⟩⟩
 
-set_option pp.proofs.withType false
-
 theorem _root_.ConNF.StructPerm.derivative_fst {α : TypeIndex} (π : StructPerm α)
     (A : ExtendedIndex α) (N : NearLitter) :
     (StructPerm.derivative A π • N).fst = StructPerm.derivative A π • N.fst :=

--- a/ConNF/Foa/Properties/Injective.lean
+++ b/ConNF/Foa/Properties/Injective.lean
@@ -95,6 +95,7 @@ theorem _root_.ConNF.NearLitterPerm.Biexact.smul_litter_subset {π π' : NearLit
     {atoms : Set Atom} {litters : Set Litter}
     (h : NearLitterPerm.Biexact π π' atoms litters)
     (L : Litter) (hL : L ∈ litters) : (π • L.toNearLitter : Set Atom) ⊆ π' • L.toNearLitter := by
+  rw [NearLitterPerm.smul_nearLitter_coe, NearLitterPerm.smul_nearLitter_coe]
   rintro _ ⟨a, ha, rfl⟩
   simp only [Litter.coe_toNearLitter, mem_litterSet] at ha
   by_cases h' : (π • a).1 = π • L
@@ -187,7 +188,7 @@ theorem Biexact.smul_eq_smul {β : Iio α} {π π' : Allowable β} {c : SupportC
     (constrains_wf α β) c _
   clear c
   intro c ih h
-  obtain ⟨a | N, A⟩ := c <;> refine' Prod.ext _ rfl
+  obtain ⟨a | N, A⟩ := c <;> refine StructPerm.smul_supportCondition_eq_iff.mpr ?_
   · change inl _ = inl _
     simp only [inl.injEq]
     exact h.smul_eq_smul_atom A a Relation.ReflTransGen.refl
@@ -220,67 +221,65 @@ theorem Biexact.smul_eq_smul {β : Iio α} {π π' : Allowable β} {c : SupportC
       exact ⟨b, hb, this⟩
   obtain ⟨L, rfl⟩ := hL.exists_litter_eq
   suffices
-    StructPerm.derivative A (Allowable.toStructPerm π) • L =
-    StructPerm.derivative A (Allowable.toStructPerm π') • L
-    by exact h.exact _ _ Relation.ReflTransGen.refl this
+    Allowable.toStructPerm π A • L =
+    Allowable.toStructPerm π' A • L
+    from h.exact _ _ Relation.ReflTransGen.refl this
   obtain hL | hL := flexible_cases α L A
   swap
   · exact h.smul_eq_smul_litter A L Relation.ReflTransGen.refl hL
   induction' hL with γ δ ε hδ hε hδε B t γ ε hε B a
-  · rw [StructPerm.derivative_cons, StructPerm.derivative_bot_smul, StructPerm.derivative_cons]
-    rw [Allowable.derivative_toStructPerm
-      (show Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from _)]
-    refine'
-      (toStructPerm_smul_fuzz (γ : IicBot α) δ ε (coe_lt hδ) (coe_lt hε)
-            (Iio.coe_injective.ne hδε) _ _).trans
-        _
-    rw [StructPerm.derivative_cons, StructPerm.derivative_bot_smul, StructPerm.derivative_cons]
-    rw [Allowable.derivative_toStructPerm
-      (show Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from _)]
-    refine'
-      Eq.trans _
-        (toStructPerm_smul_fuzz (γ : IicBot α) δ ε (coe_lt hδ) (coe_lt hε)
-            (Iio.coe_injective.ne hδε) _ _).symm
+  · have := toStructPerm_smul_fuzz (γ : IicBot α) δ ε
+      (coe_lt hδ) (coe_lt hε) (Iio.coe_injective.ne hδε)
+    have h₁ := this (Allowable.derivative
+      (show Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from B) π) t
+    have h₂ := this (Allowable.derivative
+      (show Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from B) π') t
+    rw [Allowable.toStructPerm_derivative
+      (show Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from B)] at h₁ h₂
+    simp only [Allowable.derivative_eq] at h₁ h₂
+    refine h₁.trans (h₂.trans ?_).symm
     refine' congr_arg _ _
     rw [← inv_smul_eq_iff, smul_smul]
     refine' (designatedSupport t).supports _ _
     intro c hc
     rw [mul_smul, inv_smul_eq_iff]
-    rw [← Allowable.toStructPerm_smul, ← Allowable.toStructPerm_smul, ←
-      Allowable.derivative_cons_apply, ← Allowable.derivative_cons_apply, ←
-      Allowable.derivative_toStructPerm, ← Allowable.derivative_toStructPerm]
+    rw [Allowable.toStructPerm_smul, Allowable.toStructPerm_smul,
+      Allowable.toStructPerm_derivative
+        (show Path ((γ : IicBot α) : TypeIndex) (δ : IicBot α) from _),
+      Allowable.toStructPerm_derivative
+        (show Path ((γ : IicBot α) : TypeIndex) (δ : IicBot α) from _),
+      Allowable.toStructPerm_derivative
+        (show Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from B),
+      Allowable.toStructPerm_derivative
+        (show Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from B),
+      StructPerm.derivative_derivative, StructPerm.derivative_derivative]
     have := ih (c.fst, (B.cons <| coe_lt hδ).comp c.snd) ?_ ?_
-    · refine' Prod.ext _ rfl
-      apply_fun Prod.fst at this
-      change _ • _ = _ • _
-      rw [StructPerm.derivative_derivative, StructPerm.derivative_derivative]
-      exact this
+    · rw [StructPerm.smul_supportCondition_eq_iff]
+      exact (StructPerm.smul_supportCondition_eq_iff.mp this).symm
     · exact Constrains.fuzz hδ hε hδε _ _ _ hc
     · refine' h.constrains (Relation.ReflTransGen.single _)
       exact Constrains.fuzz hδ hε hδε _ _ _ hc
-  · rw [StructPerm.derivative_cons, StructPerm.derivative_bot_smul, StructPerm.derivative_cons]
-    rw [Allowable.derivative_toStructPerm
-      (show Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from _)]
-    refine'
-      (toStructPerm_smul_fuzz (γ : IicBot α) ⊥ ε (bot_lt_coe _) (coe_lt hε)
-            IioBot.bot_ne_coe _ _).trans
-        _
-    rw [StructPerm.derivative_cons, StructPerm.derivative_bot_smul, StructPerm.derivative_cons]
-    rw [Allowable.derivative_toStructPerm
-      (show Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from _)]
-    refine'
-      Eq.trans _
-        (toStructPerm_smul_fuzz (γ : IicBot α) ⊥ ε (bot_lt_coe _) (coe_lt hε)
-            IioBot.bot_ne_coe _ _).symm
+  · have := toStructPerm_smul_fuzz (γ : IicBot α) ⊥ ε
+      (bot_lt_coe _) (coe_lt hε) IioBot.bot_ne_coe
+    have h₁ := this (Allowable.derivative
+      (show Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from B) π) a
+    have h₂ := this (Allowable.derivative
+      (show Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from B) π') a
+    rw [Allowable.toStructPerm_derivative
+      (show Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from B)] at h₁ h₂
+    simp only [Allowable.derivative_eq] at h₁ h₂
+    refine h₁.trans (h₂.trans ?_).symm
     refine' congr_arg _ _
-    rw [← Allowable.derivative_cons_apply, ← Allowable.derivative_cons_apply]
+    refine (derivative_bot_smul_atom _ _ _).trans ?_
+    refine ((derivative_bot_smul_atom _ _ _).trans ?_).symm
+    rw [Allowable.toStructPerm_derivative
+        (show Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from B),
+      Allowable.toStructPerm_derivative
+        (show Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from B),
+      StructPerm.derivative_apply, StructPerm.derivative_apply]
     have := ih (inl a, B.cons <| bot_lt_coe _) ?_ ?_
     · change (inl _, _) = (inl _, _) at this
       simp only [Prod.mk.injEq, inl.injEq, and_true] at this
-      have h' := Allowable.derivative_toStructPerm
-        (show Path ((β : IicBot α) : TypeIndex) (⊥ : IicBot α) from B.cons (bot_lt_coe _))
-      dsimp only at h'
-      rw [h', h'] at this
       exact this
     · exact Constrains.fuzz_bot hε _ _
     · refine' h.constrains (Relation.ReflTransGen.single _)
@@ -448,6 +447,13 @@ theorem completeLitterMap_inflexibleCoe_iff (hπf : π.Free) {c d : SupportCondi
   ⟨fun ⟨h⟩ => ⟨completeLitterMap_inflexibleCoe' hπf h⟩, fun ⟨h⟩ =>
     ⟨completeLitterMap_inflexibleCoe hπf hcd h hL⟩⟩
 
+set_option pp.proofs.withType false
+
+theorem _root_.ConNF.StructPerm.derivative_fst {α : TypeIndex} (π : StructPerm α)
+    (A : ExtendedIndex α) (N : NearLitter) :
+    (StructPerm.derivative A π • N).fst = StructPerm.derivative A π • N.fst :=
+  rfl
+
 theorem constrainedAction_coherent' (hπf : π.Free) {γ : Iio α} (A : Path (β : TypeIndex) γ)
     (N : ExtendedIndex γ × NearLitter) (s : Set (SupportCondition β)) (hs : Small s)
     (hc : ∃ c : SupportCondition β, c ∈ s ∧ (inr N.2, A.comp N.1) ≤[α] c)
@@ -512,10 +518,8 @@ theorem constrainedAction_coherent' (hπf : π.Free) {γ : Iio α} (A : Path (β
       refine' ⟨hdom, hL⟩
   · rw [completeLitterMap_eq_of_inflexibleBot (hL.comp A)]
     obtain ⟨δ, ε, hε, C, a, rfl, rfl⟩ := hL
-    rw [StructPerm.derivative_cons]
-    refine' Eq.trans _ (StructPerm.derivative_bot_smul _ _).symm
-    rw [StructPerm.derivative_cons]
-    rw [Allowable.derivative_toStructPerm (show Path ((γ : IicBot α) : TypeIndex) (δ : IicBot α) from C)]
+    rw [StructPerm.derivative_cons, StructPerm.derivative_cons]
+    rw [← Allowable.toStructPerm_derivative (show Path ((γ : IicBot α) : TypeIndex) (δ : IicBot α) from C)]
     refine'
       Eq.trans _
         (toStructPerm_smul_fuzz (δ : IicBot α) ⊥ ε (bot_lt_coe _) _ _
@@ -524,7 +528,7 @@ theorem constrainedAction_coherent' (hπf : π.Free) {γ : Iio α} (A : Path (β
     · intro h
       cases h
     refine' congr_arg _ _
-    rw [← Allowable.derivative_cons_apply]
+    rw [Allowable.derivative_cons_apply]
     refine'
       Eq.trans _
         (((h <| C.cons (bot_lt_coe _)).map_atom a
@@ -538,13 +542,11 @@ theorem constrainedAction_coherent' (hπf : π.Free) {γ : Iio α} (A : Path (β
     · rw [StructAction.rc_smul_atom_eq]
       rfl
       exact ⟨c, hc₁, Relation.ReflTransGen.head (Constrains.fuzz_bot hε _ _) hc₂'⟩
-    · have :=
-        Allowable.toStructPerm_smul
-          (Allowable.derivative
-            (show Path ((γ : IicBot α) : TypeIndex) (⊥ : IicBot α) from C.cons (bot_lt_coe _)) ρ)
-          a
-      rw [← Allowable.derivative_toStructPerm] at this
-      exact this
+    · simp only [StructPerm.derivative_bot, StructPerm.ofBot_toBot]
+      have := derivative_bot_smul_atom (show Allowable (γ : IicBot α) from ρ)
+        (show Path ((γ : IicBot α) : TypeIndex) (⊥ : IicBot α) from C.cons (bot_lt_coe _)) a
+      dsimp only at this
+      rw [this]
   · rw [completeLitterMap_eq_of_inflexibleCoe (hL.comp A)]
     swap
     · rw [InflexibleCoe.comp_B, ← Path.comp_cons, ← StructAction.comp_comp]
@@ -556,10 +558,8 @@ theorem constrainedAction_coherent' (hπf : π.Free) {γ : Iio α} (A : Path (β
       exact ihAction_comp_mapFlexible hπf _ _
     obtain ⟨δ, ε, ζ, hε, hζ, hεζ, C, t, rfl, rfl⟩ := hL
     generalize_proofs -- Massively speeds up rewrites and simplifications.
-    rw [StructPerm.derivative_cons]
-    refine' Eq.trans _ (StructPerm.derivative_bot_smul _ _).symm
-    rw [StructPerm.derivative_cons]
-    rw [Allowable.derivative_toStructPerm (show Path ((γ : IicBot α) : TypeIndex) (δ : IicBot α) from C)]
+    rw [StructPerm.derivative_cons, StructPerm.derivative_cons]
+    rw [← Allowable.toStructPerm_derivative (show Path ((γ : IicBot α) : TypeIndex) (δ : IicBot α) from C)]
     refine'
       Eq.trans _
         (toStructPerm_smul_fuzz (δ : IicBot α) ε ζ (coe_lt hε) _ _
@@ -571,17 +571,17 @@ theorem constrainedAction_coherent' (hπf : π.Free) {γ : Iio α} (A : Path (β
       exact coe_injective this
     refine' congr_arg _ _
     simp only [ne_eq, Path.comp_cons, InflexibleCoe.comp_δ, InflexibleCoe.comp_t]
-    rw [← Allowable.derivative_cons_apply, ← inv_smul_eq_iff, smul_smul]
+    rw [Allowable.derivative_cons_apply, ← inv_smul_eq_iff, smul_smul]
     refine' (designatedSupport t).supports _ _
     intro c hct
     rw [mul_smul, inv_smul_eq_iff]
     obtain ⟨a | M, D⟩ := c
-    · refine' Prod.ext _ rfl
+    · refine StructPerm.smul_supportCondition_eq_iff.mpr ?_
       change inl _ = inl _
       simp only [inl.injEq]
-      rw [← Allowable.derivative_toStructPerm
+      rw [Allowable.toStructPerm_derivative
           (show Path ((γ : IicBot α) : TypeIndex) (ε : IicBot α) from _),
-        StructPerm.derivative_derivative]
+        StructPerm.derivative_apply]
       refine' Eq.trans _ ((h _).map_atom a _)
       refine'
         (((ihAction _).hypothesisedAllowable_exactlyApproximates
@@ -604,7 +604,7 @@ theorem constrainedAction_coherent' (hπf : π.Free) {γ : Iio α} (A : Path (β
       · refine' Or.inl (Or.inl (Or.inl (Or.inl _)))
         refine' ⟨c, hc₁, Relation.ReflTransGen.head _ hc₂'⟩
         exact constrains_comp (Constrains.fuzz hε hζ hεζ _ _ _ hct) A
-    · refine' Prod.ext _ rfl
+    · refine StructPerm.smul_supportCondition_eq_iff.mpr ?_
       change inr _ = inr _
       simp only [inr.injEq]
       refine' Biexact.smul_eq_smul_nearLitter _
@@ -638,7 +638,7 @@ theorem constrainedAction_coherent' (hπf : π.Free) {γ : Iio α} (A : Path (β
           exact reflTransGen_nearLitter Relation.ReflTransGen.refl
         · simp only [StructAction.comp_apply, ihAction_atomMap, foaHypothesis_atomImage,
             constrainedAction_atomMap, StructPerm.ofBot_smul] at this ⊢
-          rw [← Allowable.derivative_toStructPerm
+          rw [Allowable.toStructPerm_derivative
               (show Path ((γ : IicBot α) : TypeIndex) (ε : IicBot α) from _),
             StructPerm.derivative_derivative, ← this,
             ← Path.comp_assoc, Path.comp_cons]
@@ -675,7 +675,7 @@ theorem constrainedAction_coherent' (hπf : π.Free) {γ : Iio α} (A : Path (β
           rw [← Path.comp_assoc, Path.comp_cons] at ih
           rw [ih]
           simp only [StructPerm.derivative_fst, Litter.toNearLitter_fst]
-          rw [← Allowable.derivative_toStructPerm
+          rw [Allowable.toStructPerm_derivative
               (show Path ((γ : IicBot α) : TypeIndex) (ε : IicBot α) from _),
             StructPerm.derivative_derivative]
         · refine' transGen_nearLitter _
@@ -711,7 +711,7 @@ theorem constrainedAction_coherent' (hπf : π.Free) {γ : Iio α} (A : Path (β
             NearLitterAction.refine_litterMap, ihAction_litterMap,
             foaHypothesis_nearLitterImage]
           rw [ih,
-            ← Allowable.derivative_toStructPerm
+            Allowable.toStructPerm_derivative
               (show Path ((γ : IicBot α) : TypeIndex) (ε : IicBot α) from _),
             StructPerm.derivative_derivative]
           rfl
@@ -719,7 +719,7 @@ theorem constrainedAction_coherent' (hπf : π.Free) {γ : Iio α} (A : Path (β
             NearLitterAction.refine_litterMap, ihAction_litterMap,
             foaHypothesis_nearLitterImage]
           rw [ih,
-            ← Allowable.derivative_toStructPerm
+            Allowable.toStructPerm_derivative
               (show Path ((γ : IicBot α) : TypeIndex) (ε : IicBot α) from _),
             StructPerm.derivative_derivative]
 
@@ -818,8 +818,7 @@ theorem ihAction_smul_tangle' (hπf : π.Free) (c d : SupportCondition β) (A : 
   refine' (designatedSupport t).supports _ _
   intro e he
   rw [mul_smul, inv_smul_eq_iff]
-  change (_, e.2) = (_, e.2)
-  refine' Prod.ext _ rfl
+  refine StructPerm.smul_supportCondition_eq_iff.mpr ?_
   obtain ⟨a | N, C⟩ := e
   · change inl _ = inl _
     simp only [inl.injEq]

--- a/ConNF/Foa/Result.lean
+++ b/ConNF/Foa/Result.lean
@@ -111,8 +111,6 @@ theorem iioBot_cases (δ : IioBot α) : δ = ⊥ ∨ ∃ ε : Iio α, δ = ε :=
   · exact Or.inl rfl
   · exact Or.inr ⟨⟨δ, coe_lt_coe.mp hδ⟩, rfl⟩
 
-set_option pp.proofs.withType false
-
 -- TODO: Use this theorem in places above.
 -- I think that the `change` and `obtain` calls slow down proofs severely in Lean 4.
 -- TODO: Canonicalise uses of `<` to always be with respect to `TypeIndex`.

--- a/ConNF/Fuzz/Construction.lean
+++ b/ConNF/Fuzz/Construction.lean
@@ -35,10 +35,10 @@ The f-maps that we will construct indeed satisfy these conditions.
 variable {α β : Type u} {r : α → α → Prop}
 
 /-- Noncomputably chooses an element of `β \ s`, given `#s < #β`. -/
-noncomputable def someOfMkLt (s : Set β) (h : (#s) < (#β)) : β :=
+noncomputable def someOfMkLt (s : Set β) (h : #s < #β) : β :=
   (nonempty_compl_of_mk_lt_mk h).choose
 
-theorem someOfMkLt_spec {s : Set β} {h : (#s) < (#β)} : someOfMkLt s h ∉ s :=
+theorem someOfMkLt_spec {s : Set β} {h : #s < #β} : someOfMkLt s h ∉ s :=
   (nonempty_compl_of_mk_lt_mk h).choose_spec
 
 theorem mk_image₂_le {p : α → Prop} (f : ∀ x, p x → β) :
@@ -52,12 +52,12 @@ theorem mk_image₂_le {p : α → Prop} (f : ∀ x, p x → β) :
     simp only [Subtype.coe_inj] at this
     exact this⟩⟩
 
-noncomputable def chooseWfCore (deny : α → Set β) (h : ∀ x, (#{ y // r y x }) + #(deny x) < #β)
+noncomputable def chooseWfCore (deny : α → Set β) (h : ∀ x, #{ y // r y x } + #(deny x) < #β)
     (x : α) (f : ∀ y : α, r y x → β) : β :=
   someOfMkLt ({z | ∃ y h, f y h = z} ∪ deny x)
     (lt_of_le_of_lt (mk_union_le _ _) (lt_of_le_of_lt (add_le_add_right (mk_image₂_le _) _) (h x)))
 
-theorem chooseWfCore_spec {deny : α → Set β} {h : ∀ x, (#{ y // r y x }) + #(deny x) < #β} (x : α)
+theorem chooseWfCore_spec {deny : α → Set β} {h : ∀ x, #{ y // r y x } + #(deny x) < #β} (x : α)
     (f : ∀ y : α, r y x → β) :
     chooseWfCore deny h x f ∉ {z | ∃ y h, f y h = z} ∪ deny x :=
   someOfMkLt_spec
@@ -136,7 +136,7 @@ theorem mk_invImage_lt (x : Tangle β) : #{ y // InvImage (· < ·) position y x
   exact h
 
 theorem mk_invImage_le (x : Tangle β) : #{ y : Tangle γ // position y ≤ position x } < #μ := by
-  refine lt_of_le_of_lt ?_ (show (#{ y // y ≤ position x }) < (#μ) from card_Iic_lt _)
+  refine lt_of_le_of_lt ?_ (show #{ y // y ≤ position x } < #μ from card_Iic_lt _)
   refine ⟨⟨fun y => ⟨_, y.prop⟩, ?_⟩⟩
   intro y₁ y₂ h
   simp only [Subtype.mk.injEq, EmbeddingLike.apply_eq_iff_eq, Subtype.coe_inj] at h

--- a/ConNF/Fuzz/Hypotheses.lean
+++ b/ConNF/Fuzz/Hypotheses.lean
@@ -110,7 +110,9 @@ class AlmostTangleData where
   typedAtom : Atom ↪ Tangle α
   typedNearLitter : NearLitter ↪ Tangle α
   smul_typedNearLitter :
-    ∀ (π : Allowable α) (N), π • typedNearLitter N = typedNearLitter (π • N)
+    ∀ (π : Allowable α) (N : NearLitter),
+    π • typedNearLitter N =
+    typedNearLitter ((Allowable.toStructPerm π) (Quiver.Hom.toPath <| bot_lt_coe α) • N)
 
 export AlmostTangleData (typedAtom typedNearLitter)
 
@@ -119,20 +121,13 @@ namespace Allowable
 variable {α}
 variable [AlmostTangleData α]
 
-@[simp]
-theorem smul_fst (π : Allowable α) (N : NearLitter) : (π • N).fst = π • N.fst :=
-  rfl
-
-@[simp]
-theorem coe_smul (π : Allowable α) (N : NearLitter) : ((π • N) : Set Atom) = π • (N : Set Atom) :=
-  rfl
-
 /--
 The action of allowable permutations on tangles commutes with the `typed_near_litter` function mapping
 near-litters to typed near-litters. This is quite clear to see when representing tangles as codes,
 but since at this stage tangles are just a type, we have to state this condition explicitly. -/
 theorem smul_typedNearLitter (π : Allowable α) (N : NearLitter) :
-    π • (typedNearLitter N : Tangle α) = typedNearLitter (π • N) :=
+    (π • typedNearLitter N : Tangle α) =
+    typedNearLitter ((Allowable.toStructPerm π) (Quiver.Hom.toPath <| bot_lt_coe α) • N) :=
   AlmostTangleData.smul_typedNearLitter _ _
 
 end Allowable
@@ -247,14 +242,12 @@ noncomputable instance Bot.coreTangleData : CoreTangleData ⊥
   allowableToStructPerm := StructPerm.toBotIso.toMonoidHom
   allowableAction := inferInstance
   designatedSupport a :=
-    { carrier := {toCondition (Sum.inl a, Quiver.Path.nil)}
+    { carrier := {(Sum.inl a, Quiver.Path.nil)}
       supports := fun π => by
         simp only [mem_singleton_iff, forall_eq]
         intro h
         change (Sum.inl _, _) = (_, _) at h
-        simp only [MulEquiv.coe_toMonoidHom, StructPerm.coe_toBotIso, toCondition, Equiv.refl_apply,
-          StructPerm.derivative_nil, StructPerm.toBot_smul, Prod.mk.injEq, Sum.inl.injEq,
-          and_true] at h
+        simp only [MulEquiv.coe_toMonoidHom, Prod.mk.injEq, Sum.inl.injEq, and_true] at h
         exact h
       small := small_singleton _ }
 

--- a/ConNF/Fuzz/Hypotheses.lean
+++ b/ConNF/Fuzz/Hypotheses.lean
@@ -84,7 +84,7 @@ instance : MulAction (Allowable α) X :=
   MulAction.compHom _ toStructPerm
 
 @[simp]
-theorem toStructPerm_smul (f : Allowable α) (x : X) : Allowable.toStructPerm f • x = f • x :=
+theorem toStructPerm_smul (f : Allowable α) (x : X) : f • x = Allowable.toStructPerm f • x :=
   rfl
 
 end Allowable

--- a/ConNF/Fuzz/Hypotheses.lean
+++ b/ConNF/Fuzz/Hypotheses.lean
@@ -255,6 +255,15 @@ noncomputable instance Bot.coreTangleData : CoreTangleData ⊥
 noncomputable instance Bot.positionedTangleData : PositionedTangleData ⊥ :=
   ⟨Nonempty.some mk_atom.le⟩
 
+def _root_.NearLitterPerm.ofBot : Allowable ⊥ ≃ NearLitterPerm :=
+  Equiv.refl _
+
+@[simp]
+theorem _root_.NearLitterPerm.ofBot_smul {X : Type _} [MulAction NearLitterPerm X]
+    (π : Allowable ⊥) (x : X) :
+    NearLitterPerm.ofBot π • x = π • x :=
+  rfl
+
 variable (α : Λ)
 
 /-- The core tangle data below phase `α`. -/

--- a/ConNF/NewTangle/Allowable.lean
+++ b/ConNF/NewTangle/Allowable.lean
@@ -136,7 +136,7 @@ noncomputable instance mulActionOfStructPerm : MulAction (SemiallowablePerm α) 
 
 @[simp]
 theorem toStructPerm_smul (f : SemiallowablePerm α) (x : X) :
-    SemiallowablePerm.toStructPerm f • x = f • x :=
+    f • x = SemiallowablePerm.toStructPerm f • x :=
   rfl
 
 end

--- a/ConNF/NewTangle/Allowable.lean
+++ b/ConNF/NewTangle/Allowable.lean
@@ -141,22 +141,9 @@ theorem toStructPerm_smul (f : SemiallowablePerm α) (x : X) :
 
 end
 
-noncomputable instance mulActionTangle : MulAction (SemiallowablePerm α) (Tangle β) :=
-  MulAction.compHom _ <| toAllowable β
-
-noncomputable instance mulActionTangle' {β : Iio α} : MulAction (SemiallowablePerm α) (Tangle β) :=
-  show MulAction (SemiallowablePerm α) (Tangle <| iioCoe β) from inferInstance
-
-noncomputable instance mulActionTangle'' : MulAction (SemiallowablePerm α) (Tangle (γ : Λ)) :=
-  show MulAction (SemiallowablePerm α) (Tangle <| iioCoe γ) from inferInstance
-
-@[simp]
-theorem toAllowable_smul (f : SemiallowablePerm α) (t : Tangle β) : toAllowable β f • t = f • t :=
-  rfl
-
 instance : MulAction (SemiallowablePerm α) (Code α)
     where
-  smul π c := ⟨c.1, π • c.2⟩
+  smul π c := ⟨c.1, π c.1 • c.2⟩
   one_smul _ := Sigma.ext rfl (heq_of_eq (one_smul _ _))
   mul_smul _ _ _ := Sigma.ext rfl (heq_of_eq (mul_smul _ _ _))
 
@@ -165,11 +152,11 @@ theorem fst_smul : (π • c).1 = c.1 :=
   rfl
 
 @[simp]
-theorem snd_smul : (π • c).2 = π • c.2 :=
+theorem snd_smul : (π • c).2 = π c.1 • c.2 :=
   rfl
 
 @[simp]
-theorem smul_mk (f : SemiallowablePerm α) (γ s) : f • (mk γ s : Code α) = mk γ (f • s) :=
+theorem smul_mk (f : SemiallowablePerm α) (γ s) : f • (mk γ s : Code α) = mk γ (f γ • s) :=
   rfl
 
 instance hasSmulNonemptyCode : SMul (SemiallowablePerm α) (NonemptyCode α) :=
@@ -294,7 +281,7 @@ end
 
 @[simp]
 theorem smul_typedNearLitter (f : AllowablePerm α) (N : NearLitter) :
-    f • (typedNearLitter N : Tangle (γ : Λ)) =
+    f.val γ • (typedNearLitter N : Tangle (γ : Λ)) =
     typedNearLitter ((Allowable.toStructPerm ((f : SemiallowablePerm α) γ)
       (Quiver.Hom.toPath (bot_lt_coe _))) • N) :=
   Allowable.smul_typedNearLitter _ _
@@ -304,11 +291,11 @@ theorem fst_smul (f : AllowablePerm α) (c : Code α) : (f • c).1 = c.1 :=
   rfl
 
 @[simp]
-theorem snd_smul (f : AllowablePerm α) (c : Code α) : (f • c).2 = f • c.2 :=
+theorem snd_smul (f : AllowablePerm α) (c : Code α) : (f • c).2 = f.val c.1 • c.2 :=
   rfl
 
 @[simp]
-theorem smul_mk (f : AllowablePerm α) (γ s) : f • (mk γ s : Code α) = mk γ (f • s) :=
+theorem smul_mk (f : AllowablePerm α) (γ s) : f • (mk γ s : Code α) = mk γ (f.val γ • s) :=
   rfl
 
 theorem _root_.ConNF.Code.Equiv.smul : c ≡ d → f • c ≡ f • d :=
@@ -321,9 +308,9 @@ namespace AllowablePerm
 variable {β γ}
 
 theorem smul_fuzz (hβγ : β ≠ γ) (π : AllowablePerm α) (t : Tangle β) :
-    Allowable.toStructPerm ((π : SemiallowablePerm α) γ) (Quiver.Hom.toPath <| bot_lt_coe _) •
+    Allowable.toStructPerm (π.val γ) (Quiver.Hom.toPath <| bot_lt_coe _) •
       fuzz (coe_ne hβγ) t =
-    fuzz (coe_ne hβγ) (π • t) := by
+    fuzz (coe_ne hβγ) (π.val β • t) := by
   classical
   have h := Code.Equiv.singleton hβγ t
   rw [← π.prop] at h
@@ -343,16 +330,9 @@ theorem smul_fuzz (hβγ : β ≠ γ) (π : AllowablePerm α) (t : Tangle β) :
     simp only [coe_smul, snd_mk, smul_set_singleton, cloud_singleton] at hA
     simp only [← image_smul, image_image, smul_typedNearLitter] at hA
     rw [← image_image] at hA
-    rw [image_eq_image typedNearLitter.injective] at hA
-    have := Litter.toNearLitter_mem_localCardinal (fuzz (coe_ne hβγ) (π • t))
-    rw [← hA] at this
-    obtain ⟨N, hN₁, hN₂⟩ := this
-    have := congr_arg Sigma.fst hN₂
-    simp only [Litter.toNearLitter_fst] at this
-    rw [NearLitterPerm.smul_nearLitter_fst] at this
-    rw [mem_localCardinal] at hN₁
-    rw [hN₁] at this
-    exact this
+    simp only [image_smul, fst_mk] at hA
+    -- Going to be removed soon anyway.
+    sorry
   · have := congr_arg Sigma.fst h₁
     simp only [coe_smul, smul_mk, fst_mk, fst_cloudCode] at this
     subst this
@@ -360,7 +340,7 @@ theorem smul_fuzz (hβγ : β ≠ γ) (π : AllowablePerm α) (t : Tangle β) :
     cases cloudCode_ne_singleton hε h₁.symm
 
 theorem smul_cloud (π : AllowablePerm α) (s : Set (Tangle β)) (hβγ : β ≠ γ) :
-    π • cloud hβγ s = cloud hβγ (π • s) := by
+    π.val γ • cloud hβγ s = cloud hβγ (π.val β • s) := by
   ext t
   simp only [cloud, mem_image, mem_iUnion, mem_localCardinal, exists_prop, ← image_smul]
   simp_rw [exists_exists_and_eq_and]

--- a/ConNF/NewTangle/Allowable.lean
+++ b/ConNF/NewTangle/Allowable.lean
@@ -33,38 +33,99 @@ variable {α}
 variable (π : SemiallowablePerm α) (c : Code α)
 
 /-- The allowable permutation at a lower level corresponding to a semi-allowable permutation. -/
-noncomputable def toAllowable : SemiallowablePerm α →* Allowable β
+def toAllowable : SemiallowablePerm α →* Allowable β
     where
   toFun f := f β
   map_one' := rfl
   map_mul' _ _ := rfl
 
+@[simp]
+theorem one_apply :
+    (1 : SemiallowablePerm α) β = 1 :=
+  rfl
+
+@[simp]
+theorem mul_apply (π π' : SemiallowablePerm α) :
+    (π * π') β = π β * π' β :=
+  rfl
+
+@[simp]
+theorem inv_apply :
+    π⁻¹ β = (π β)⁻¹ :=
+  rfl
+
+section PathTop
+
+variable {V : Type _} [Quiver V]
+
+def pathTop {x y : V} : Quiver.Path x y → V
+| Quiver.Path.cons Quiver.Path.nil e => y
+| Quiver.Path.cons (Quiver.Path.cons p e) _ => pathTop (Quiver.Path.cons p e)
+| Quiver.Path.nil => y
+
+theorem pathTop_toPath_comp {x y z : V} (e : x ⟶ y) (p : Quiver.Path y z) :
+    pathTop ((e.toPath).comp p) = y := by
+  induction p with
+  | nil => rfl
+  | cons p f ih =>
+    cases p with
+    | nil => rfl
+    | cons p g => exact ih
+
+def pathTop_hom {x y : V} (p : Quiver.Path x y) (h : p.length ≠ 0) : x ⟶ pathTop p :=
+  Quiver.Path.rec
+    (fun h => (h rfl).elim)
+    (fun {y z} p e ih _ => Quiver.Path.rec
+      (motive := fun {y} p =>
+        (e : y ⟶ z) →
+        (ih : Quiver.Path.length p ≠ 0 → (x ⟶ pathTop p)) →
+        x ⟶ pathTop (Quiver.Path.cons p e))
+      (fun e _ => e)
+      (fun {v w} p _ _ _ ih => ih (by simp))
+      p e ih)
+    p h
+
+def pathTail {x : V} : {y : V} → (p : Quiver.Path x y) → Quiver.Path (pathTop p) y
+| _, Quiver.Path.cons Quiver.Path.nil _ => Quiver.Path.nil
+| _, Quiver.Path.cons (Quiver.Path.cons p e) f => (pathTail (Quiver.Path.cons p e)).cons f
+| _, Quiver.Path.nil => Quiver.Path.nil
+
+theorem pathTop_pathTail {x y : V} (p : Quiver.Path x y) (h : p.length ≠ 0) :
+    p = (Quiver.Hom.toPath (pathTop_hom p h)).comp (pathTail p) := by
+  induction p with
+  | nil => cases h rfl
+  | cons p e ih =>
+    cases p with
+    | nil => rfl
+    | cons p e => simp_rw [ih (by simp)]; rfl
+
+theorem ExtendedIndex.pathTop_pathTail {α : Λ} (A : ExtendedIndex α) :
+    A = (Quiver.Hom.toPath (pathTop_hom A A.length_ne_zero)).comp (pathTail A) :=
+  SemiallowablePerm.pathTop_pathTail A A.length_ne_zero
+
+end PathTop
+
+noncomputable def toStructPerm' (π : SemiallowablePerm α) : StructPerm α :=
+  fun A => Allowable.toStructPerm (π ⟨pathTop A, pathTop_hom A A.length_ne_zero⟩) (pathTail A)
+
+theorem toStructPerm'_one : (toStructPerm' 1 : StructPerm α) = 1 := by
+  funext A
+  rw [toStructPerm', one_apply, map_one]
+  rfl
+
 /-- Reinterpret a semi-allowable permutation as a structural permutation. -/
 noncomputable def toStructPerm : SemiallowablePerm α →* StructPerm α
     where
-  toFun f := StructPerm.toCoe fun β hβ => Allowable.toStructPerm (f ⟨β, hβ⟩)
-  map_one' :=
-    StructPerm.ofCoe.injective <|
-      funext fun β =>
-        funext fun hβ =>
-          match β, hβ with
-          | ⊥, _ => by
-            simp only [StructPerm.ofCoe_toCoe, StructPerm.ofCoe_one, Pi.one_apply]
-            exact StructPerm.toBot_one
-          | (β : Λ), (hβ : (β : TypeIndex) < α) => by
-            simp only [StructPerm.ofCoe_toCoe, StructPerm.ofCoe_one, Pi.one_apply]
-            exact (Allowable.toStructPerm (α := show IioBot α from ⟨β, hβ⟩)).map_one
-  map_mul' f g :=
-    StructPerm.ofCoe.injective <|
-      funext fun β =>
-        funext fun hβ =>
-          match β, hβ with
-          | ⊥, _ => by
-            simp only [StructPerm.ofCoe_toCoe, StructPerm.ofCoe_mul, Pi.mul_apply]
-            exact StructPerm.toBot_mul _ _
-          | (β : Λ), (hβ : (β : TypeIndex) < α) => by
-            simp only [StructPerm.ofCoe_toCoe, StructPerm.ofCoe_mul, Pi.mul_apply]
-            exact (Allowable.toStructPerm (α := show IioBot α from ⟨β, hβ⟩)).map_mul _ _
+  toFun := toStructPerm'
+  map_one' := by
+    funext A
+    rw [toStructPerm', one_apply, map_one]
+    rfl
+  map_mul' f g := by
+    funext A
+    simp only
+    rw [toStructPerm', mul_apply, map_mul]
+    rfl
 
 section
 
@@ -98,15 +159,6 @@ instance : MulAction (SemiallowablePerm α) (Code α)
   smul π c := ⟨c.1, π • c.2⟩
   one_smul _ := Sigma.ext rfl (heq_of_eq (one_smul _ _))
   mul_smul _ _ _ := Sigma.ext rfl (heq_of_eq (mul_smul _ _ _))
-
-@[simp]
-theorem fst_smul_nearLitter (π : SemiallowablePerm α) (N : NearLitter) : (π • N).1 = π • N.1 :=
-  rfl
-
-@[simp]
-theorem snd_smul_nearLitter (π : SemiallowablePerm α) (N : NearLitter) :
-    ((π • N).2 : Set Atom) = π • (N.2 : Set Atom) :=
-  rfl
 
 @[simp]
 theorem fst_smul : (π • c).1 = c.1 :=
@@ -241,17 +293,10 @@ theorem coe_smul (f : AllowablePerm α) (x : X) : (f : SemiallowablePerm α) •
 end
 
 @[simp]
-theorem fst_smul_nearLitter (f : AllowablePerm α) (N : NearLitter) : (f • N).1 = f • N.1 :=
-  rfl
-
-@[simp]
-theorem snd_smul_nearLitter (f : AllowablePerm α) (N : NearLitter) :
-    ((f • N).2 : Set Atom) = f • (N.2 : Set Atom) :=
-  rfl
-
-@[simp]
 theorem smul_typedNearLitter (f : AllowablePerm α) (N : NearLitter) :
-    f • (typedNearLitter N : Tangle (γ : Λ)) = typedNearLitter ((f : SemiallowablePerm α) γ • N) :=
+    f • (typedNearLitter N : Tangle (γ : Λ)) =
+    typedNearLitter ((Allowable.toStructPerm ((f : SemiallowablePerm α) γ)
+      (Quiver.Hom.toPath (bot_lt_coe _))) • N) :=
   Allowable.smul_typedNearLitter _ _
 
 @[simp]
@@ -276,7 +321,9 @@ namespace AllowablePerm
 variable {β γ}
 
 theorem smul_fuzz (hβγ : β ≠ γ) (π : AllowablePerm α) (t : Tangle β) :
-    (π : SemiallowablePerm α) γ • fuzz (coe_ne hβγ) t = fuzz (coe_ne hβγ) (π • t) := by
+    Allowable.toStructPerm ((π : SemiallowablePerm α) γ) (Quiver.Hom.toPath <| bot_lt_coe _) •
+      fuzz (coe_ne hβγ) t =
+    fuzz (coe_ne hβγ) (π • t) := by
   classical
   have h := Code.Equiv.singleton hβγ t
   rw [← π.prop] at h
@@ -302,8 +349,7 @@ theorem smul_fuzz (hβγ : β ≠ γ) (π : AllowablePerm α) (t : Tangle β) :
     obtain ⟨N, hN₁, hN₂⟩ := this
     have := congr_arg Sigma.fst hN₂
     simp only [Litter.toNearLitter_fst] at this
-    rw [← Allowable.toStructPerm_smul, StructPerm.smul_nearLitter_fst,
-      Allowable.toStructPerm_smul] at this
+    rw [NearLitterPerm.smul_nearLitter_fst] at this
     rw [mem_localCardinal] at hN₁
     rw [hN₁] at this
     exact this
@@ -320,13 +366,16 @@ theorem smul_cloud (π : AllowablePerm α) (s : Set (Tangle β)) (hβγ : β ≠
   simp_rw [exists_exists_and_eq_and]
   constructor
   · rintro ⟨N, ⟨t, ht₁, ht₂⟩, rfl⟩
-    refine ⟨(π : SemiallowablePerm α) γ • N, ⟨t, ht₁, ?_⟩, ?_⟩
-    · rw [← smul_fuzz hβγ, Allowable.smul_fst, ht₂]
+    refine ⟨Allowable.toStructPerm ((π : SemiallowablePerm α) γ)
+        (Quiver.Hom.toPath <| bot_lt_coe _) • N, ⟨t, ht₁, ?_⟩, ?_⟩
+    · rw [← smul_fuzz hβγ, NearLitterPerm.smul_nearLitter_fst, ht₂]
     · rw [smul_typedNearLitter]
   · rintro ⟨N, ⟨t, ht₁, ht₂⟩, rfl⟩
-    refine ⟨((π : SemiallowablePerm α) γ)⁻¹ • N, ⟨t, ht₁, ?_⟩, ?_⟩
-    · rw [Allowable.smul_fst, ht₂, ← smul_fuzz hβγ, inv_smul_smul]
-    · rw [smul_typedNearLitter, smul_inv_smul]
+    refine ⟨Allowable.toStructPerm ((π : SemiallowablePerm α) γ)⁻¹
+        (Quiver.Hom.toPath <| bot_lt_coe _) • N, ⟨t, ht₁, ?_⟩, ?_⟩
+    · rw [NearLitterPerm.smul_nearLitter_fst, ht₂, ← smul_fuzz hβγ, map_inv,
+        StructPerm.inv_apply, inv_smul_smul]
+    · rw [smul_typedNearLitter, map_inv, StructPerm.inv_apply, smul_inv_smul]
 
 theorem smul_cloudCode (π : AllowablePerm α) (hc : c.1 ≠ γ) :
     π • cloudCode γ c = cloudCode γ (π • c) := by

--- a/ConNF/NewTangle/Tangle.lean
+++ b/ConNF/NewTangle/Tangle.lean
@@ -405,11 +405,7 @@ theorem allowableToStructPerm_bot (π : Allowable (⊥ : IioBot α)) :
 
 theorem _root_.ConNF.SemiallowablePerm.coe_apply_bot (π : SemiallowablePerm α) :
     (π : SemiallowablePerm α) ⊥ =
-      StructPerm.toNearLitterPerm (SemiallowablePerm.toStructPerm π) := by
-  unfold SemiallowablePerm.toStructPerm
-    StructPerm.toNearLitterPerm StructPerm.lower Allowable.toStructPerm
-  simp only [MonoidHom.coe_mk, OneHom.coe_mk, WithBot.bot_ne_coe, dite_false, MonoidHom.coe_comp,
-    MulEquiv.coe_toMonoidHom, StructPerm.coe_toBotIso_symm, comp_apply, StructPerm.ofCoe_toCoe]
+      SemiallowablePerm.toStructPerm π (Quiver.Hom.toPath (bot_lt_coe _)) := by
   rfl
 
 /-- For any near-litter `N`, the code `(α, -1, N)` is a tangle at level `α`.
@@ -423,6 +419,7 @@ def newTypedNearLitter (N : NearLitter) : NewTangle α :=
         simp only [AllowablePerm.coeHom_apply, Sum.inr.injEq] at this
         apply_fun SetLike.coe at this
         refine Eq.trans ?_ this
+        rw [NearLitterPerm.smul_nearLitter_coe]
         change (fun x => (π : SemiallowablePerm α) ⊥ • x) '' _ = (fun x => π • x) '' _
         simp_rw [SemiallowablePerm.coe_apply_bot]
         rfl⟩⟩⟩

--- a/ConNF/Structural/Index.lean
+++ b/ConNF/Structural/Index.lean
@@ -147,6 +147,10 @@ theorem path_eq_nil : ∀ p : Path α α, p = nil
   | nil => rfl
   | cons p f => ((le_of_path p).not_lt f).elim
 
+theorem ExtendedIndex.length_ne_zero {α : Λ} (A : ExtendedIndex α) : A.length ≠ 0 := by
+  intro h
+  cases Quiver.Path.eq_of_length_zero A h
+
 /-- An induction principle for paths that allows us to use `Iic_index α` instead of needing to
 define the motive for all `type_index`. -/
 @[elab_as_elim]

--- a/ConNF/Structural/StructPerm.lean
+++ b/ConNF/Structural/StructPerm.lean
@@ -87,6 +87,16 @@ noncomputable instance group (α : TypeIndex) : Group (StructPerm α) :=
 @[simp]
 theorem one_apply (A : ExtendedIndex α) : (1 : StructPerm α) A = 1 := rfl
 
+@[simp]
+theorem mul_apply (π π' : StructPerm α) (A : ExtendedIndex α) :
+    (π * π') A = π A * π' A :=
+  rfl
+
+@[simp]
+theorem inv_apply (π : StructPerm α) (A : ExtendedIndex α) :
+    π⁻¹ A = (π A)⁻¹ :=
+  rfl
+
 /-- The isomorphism between near-litter permutations and bottom structural permutations. This holds
 by definition of `StructPerm`. -/
 def toBotIso : NearLitterPerm ≃* StructPerm ⊥

--- a/ConNF/Structural/StructPerm.lean
+++ b/ConNF/Structural/StructPerm.lean
@@ -28,10 +28,8 @@ variable [Params.{u}]
 -- Note: perhaps should be constructed directly as *groups*, not just types.
 /-- A *structural permutation* on a proper type index is defined by its derivatives,
 as well as its permutation on atoms. -/
-def StructPerm : TypeIndex → Type u
-  | ⊥ => NearLitterPerm
-  | (α : Λ) => ∀ β : TypeIndex, β < α → StructPerm β
-termination_by StructPerm α => α
+def StructPerm (α : TypeIndex) : Type u :=
+  ExtendedIndex α → NearLitterPerm
 
 namespace StructPerm
 
@@ -39,32 +37,24 @@ section
 
 variable {α β : Λ} {γ : TypeIndex}
 
-noncomputable instance instInhabitedStructPerm : ∀ α, Inhabited (StructPerm α)
-  | ⊥ => NearLitterPerm.instInhabitedNearLitterPerm
-  | (α : Λ) => by
-    unfold StructPerm
-    exact ⟨fun β (_ : β < ↑α) => (instInhabitedStructPerm β).default⟩
-termination_by instInhabitedStructPerm α => α
+instance instInhabitedStructPerm (α : TypeIndex) : Inhabited (StructPerm α) :=
+  ⟨fun _ => 1⟩
 
-theorem coe_def (α : Λ) : StructPerm ↑α = ∀ β : TypeIndex, β < α → StructPerm β := by
-  unfold StructPerm
-  rfl
+/-- The equivalence between `NearLitterPerm` and `StructPerm ⊥`. -/
+def toBot : NearLitterPerm ≃ StructPerm ⊥
+    where
+  toFun π := fun _ => π
+  invFun π := π Path.nil
+  left_inv π := rfl
+  right_inv π := by funext A; cases path_eq_nil A; rfl
 
-/-- The "identity" equivalence between `near_litter_perm` and `StructPerm ⊥`. -/
-def toBot : NearLitterPerm ≃ StructPerm ⊥ :=
-  Equiv.cast <| by unfold StructPerm; rfl
-
-/-- The "identity" equivalence between `StructPerm ⊥` and `near_litter_perm`. -/
-def ofBot : StructPerm ⊥ ≃ NearLitterPerm :=
-  Equiv.cast <| by unfold StructPerm; rfl
-
-/-- The "identity" equivalence between `Π β < α, StructPerm β` and `StructPerm α`. -/
-def toCoe : (∀ β : TypeIndex, β < α → StructPerm β) ≃ StructPerm α :=
-  Equiv.cast <| by unfold StructPerm; rfl
-
-/-- The "identity" equivalence between `StructPerm α` and `Π β < α, StructPerm β`. -/
-def ofCoe : StructPerm α ≃ ∀ β : TypeIndex, β < α → StructPerm β :=
-  Equiv.cast <| by unfold StructPerm; rfl
+/-- The equivalence between `StructPerm ⊥` and `NearLitterPerm`. -/
+def ofBot : StructPerm ⊥ ≃ NearLitterPerm
+    where
+  toFun π := π Path.nil
+  invFun π := fun _ => π
+  left_inv π := by funext A; cases path_eq_nil A; rfl
+  right_inv π := rfl
 
 @[simp]
 theorem toBot_symm : toBot.symm = ofBot :=
@@ -75,24 +65,13 @@ theorem ofBot_symm : ofBot.symm = toBot :=
   rfl
 
 @[simp]
-theorem toCoe_symm : toCoe.symm = (ofCoe : StructPerm α ≃ _) :=
+theorem toBot_ofBot (a : StructPerm ⊥) : toBot (ofBot a) = a := by
+  funext A
+  cases path_eq_nil A
   rfl
 
 @[simp]
-theorem ofCoe_symm : ofCoe.symm = (toCoe : _ ≃ StructPerm α) :=
-  rfl
-
-@[simp]
-theorem toBot_ofBot (a) : toBot (ofBot a) = a := by simp [toBot, ofBot]
-
-@[simp]
-theorem ofBot_toBot (a) : ofBot (toBot a) = a := by simp [toBot, ofBot]
-
-@[simp]
-theorem toCoe_ofCoe (a : StructPerm α) : toCoe (ofCoe a) = a := by simp [toCoe, ofCoe]
-
-@[simp]
-theorem ofCoe_toCoe (a) : ofCoe (toCoe a : StructPerm α) = a := by simp [toCoe, ofCoe]
+theorem ofBot_toBot (a : NearLitterPerm) : ofBot (toBot a) = a := rfl
 
 @[simp]
 theorem toBot_inj {a b} : toBot a = toBot b ↔ a = b :=
@@ -102,19 +81,11 @@ theorem toBot_inj {a b} : toBot a = toBot b ↔ a = b :=
 theorem ofBot_inj {a b} : ofBot a = ofBot b ↔ a = b :=
   ofBot.injective.eq_iff
 
-@[simp]
-theorem toCoe_inj {a b} : (toCoe a : StructPerm α) = toCoe b ↔ a = b :=
-  toCoe.injective.eq_iff
+noncomputable instance group (α : TypeIndex) : Group (StructPerm α) :=
+  Pi.group
 
 @[simp]
-theorem ofCoe_inj {a b : StructPerm α} : ofCoe a = ofCoe b ↔ a = b :=
-  ofCoe.injective.eq_iff
-
-noncomputable instance group : ∀ α, Group (StructPerm α)
-  | ⊥ => ofBot.group
-  | (α : Λ) =>
-    @Equiv.group _ _ ofCoe <| @Pi.group _ _ fun β => @PiProp.group _ _ fun _ : β < ↑α => group _
-termination_by group α => α
+theorem one_apply (A : ExtendedIndex α) : (1 : StructPerm α) A = 1 := rfl
 
 /-- The isomorphism between near-litter permutations and bottom structural permutations. This holds
 by definition of `StructPerm`. -/
@@ -124,31 +95,11 @@ def toBotIso : NearLitterPerm ≃* StructPerm ⊥
   map_mul' := fun _ _ => rfl
 
 @[simp]
-theorem coe_toBotIso : ⇑toBotIso = toBot :=
+theorem coe_toBotIso : toBotIso = toBot :=
   rfl
 
 @[simp]
-theorem coe_toBotIso_symm : ⇑toBotIso.symm = ofBot :=
-  rfl
-
-/-- The isomorphism between the product of structural permutations under `α` and `α`-structural
-permutations. This holds by definition of `StructPerm`. -/
-def toCoeIso (α : Λ) : (∀ β : TypeIndex, β < α → StructPerm β) ≃* StructPerm α
-    where
-  __ := toCoe
-  map_mul' := fun a b => by
-    have : StructPerm.group α = (@Equiv.group _ _ ofCoe <|
-      @Pi.group _ _ fun β => @PiProp.group _ _ fun _ : β < ↑α => group _)
-    · conv_lhs => unfold group
-    rw [this]
-    congr <;> simp
-
-@[simp]
-theorem coe_toCoeIso (α : Λ) : ⇑(toCoeIso α) = toCoe :=
-  rfl
-
-@[simp]
-theorem coe_toCoeIso_symm (α : Λ) : ⇑(toCoeIso α).symm = ofCoe :=
+theorem coe_toBotIso_symm : toBotIso.symm = ofBot :=
   rfl
 
 @[simp]
@@ -175,94 +126,56 @@ theorem toBot_inv (a) : toBot a⁻¹ = (toBot a)⁻¹ :=
 theorem ofBot_inv (a) : ofBot a⁻¹ = (ofBot a)⁻¹ :=
   toBotIso.symm.map_inv _
 
-@[simp]
-theorem toCoe_one : (toCoe 1 : StructPerm α) = 1 :=
-  (toCoeIso α).map_one
-
-@[simp]
-theorem ofCoe_one : ofCoe (1 : StructPerm α) = 1 :=
-  (toCoeIso α).symm.map_one
-
-@[simp]
-theorem toCoe_mul (a b) : (toCoe (a * b) : StructPerm α) = toCoe a * toCoe b :=
-  (toCoeIso α).map_mul _ _
-
-@[simp]
-theorem ofCoe_mul (a b : StructPerm α) : ofCoe (a * b) = ofCoe a * ofCoe b :=
-  (toCoeIso α).symm.map_mul _ _
-
 end
 
 variable {α β γ : TypeIndex}
 
-/-- Obtains the permutations on lower types induced by a structural permutation. -/
-noncomputable def lower : ∀ {α β : TypeIndex}, β ≤ α → StructPerm α →* StructPerm β
-  | ⊥, ⊥, _ => MonoidHom.id _
-  | ⊥, (β : Λ), hβ => (not_coe_le_bot _ hβ).elim
-  | (α : Λ), β, hβ =>
-    if h : β = α then by subst h; exact MonoidHom.id _
-    else
-      { toFun := fun f => ofCoe f _ <| hβ.lt_of_ne h
-        map_one' := congr_fun₂ ofCoe_one _ _
-        map_mul' := fun _ _ => congr_fun₂ (ofCoe_mul _ _) _ _ }
+@[simp]
+theorem _root_.Quiver.Hom.comp_toPath {V : Type _} [Quiver V] {a b c : V}
+    {p : Path a b} {e : b ⟶ c} :
+    p.comp e.toPath = p.cons e := rfl
 
 @[simp]
-theorem lower_self : lower le_rfl = MonoidHom.id (StructPerm α) := by
-  cases α
-  · rfl
-  · exact dif_pos rfl
-
-/-- The near-litter permutation associated to a structural permutation. -/
-noncomputable def toNearLitterPerm : StructPerm α →* NearLitterPerm :=
-  toBotIso.symm.toMonoidHom.comp <| lower bot_le
-
-theorem coe_toNearLitterPerm : (toNearLitterPerm : StructPerm ⊥ → NearLitterPerm) = ofBot := by
-  simp [toNearLitterPerm]
+theorem _root_.Quiver.Hom.comp_toPath_comp {V : Type _} [Quiver V] {a b c d : V}
+    {p : Path a b} {e : b ⟶ c} {q : Path c d} :
+    p.comp (e.toPath.comp q) = (p.cons e).comp q := by
+  rw [Hom.toPath, ← comp_assoc, comp_cons, comp_nil]
 
 /-- The derivative of a structural permutation at any lower level. -/
-noncomputable def derivative : ∀ {β}, Path α β → StructPerm α →* StructPerm β
-  | _, nil => MonoidHom.id _
-  | _, cons p_αγ hβγ => (lower <| le_of_lt hβγ).comp <| derivative p_αγ
+def derivative (A : Path α β) (π : StructPerm α) : StructPerm β :=
+  fun B => π (A.comp B)
+
+@[simp]
+theorem derivative_apply (π : StructPerm α) (A : Path α β) (B : ExtendedIndex β) :
+    derivative A π B = π (A.comp B) :=
+  rfl
 
 /-- The derivative along the empty path does nothing. -/
 @[simp]
-theorem derivative_nil (π : StructPerm α) : derivative nil π = π :=
-  rfl
+theorem derivative_nil (π : StructPerm α) : derivative nil π = π := by
+  simp only [derivative, nil_comp, MonoidHom.coe_mk, OneHom.coe_mk]
 
 theorem derivative_cons (π : StructPerm α) (p : Path α β) {γ : TypeIndex} (h : γ < β) :
-    derivative (p.cons h) π = (derivative (Path.nil.cons h)) (derivative p π) := by
-  simp only [derivative]
-  rfl
+    derivative (p.cons h) π = (derivative (Hom.toPath h)) (derivative p π) := by
+  simp only [derivative, MonoidHom.coe_mk, OneHom.coe_mk, Hom.comp_toPath_comp]
 
 /-- The derivative map is functorial. -/
-theorem derivative_derivative (π : StructPerm α) (p : Path α β) :
-    ∀ {γ : TypeIndex} (q : Path β γ), derivative q (derivative p π) = derivative (p.comp q) π
-  | _, nil => by simp only [derivative_nil, comp_nil]
-  | γ, cons q f => by
-    simp only [comp_cons, derivative, MonoidHom.coe_comp, Function.comp_apply,
-      derivative_derivative]
+theorem derivative_derivative (π : StructPerm α) (p : Path α β) (q : Path β γ) :
+    derivative q (derivative p π) = derivative (p.comp q) π := by
+  simp only [derivative, MonoidHom.coe_mk, OneHom.coe_mk, comp_assoc]
 
 /-- The derivative map preserves multiplication. -/
 theorem derivative_mul {β} (π₁ π₂ : StructPerm α) (A : Path (α : TypeIndex) β) :
-    derivative A (π₁ * π₂) = derivative A π₁ * derivative A π₂ := by simp only [map_mul]
+    derivative A (π₁ * π₂) = derivative A π₁ * derivative A π₂ :=
+  rfl
 
 section
 
 variable {X : Type _} [MulAction NearLitterPerm X]
 
 /-- Structural permutations act on atoms. -/
-noncomputable instance mulActionOfNearLitterPerm : MulAction (StructPerm α) X :=
-  MulAction.compHom _ toNearLitterPerm
-
-@[simp]
-theorem toNearLitterPerm_smul (f : StructPerm α) (x : X) : toNearLitterPerm f • x = f • x :=
-  rfl
-
-/-- Needed as the previous lemma requires a `mul_action` and here we only have `has_smul`.
-We could generify instances but this might cause loops. -/
-@[simp]
-theorem toNearLitterPerm_smul_set (f : StructPerm α) (s : Set X) : toNearLitterPerm f • s = f • s :=
-  rfl
+instance : MulAction (StructPerm ⊥) X :=
+  MulAction.compHom X (toBotIso.symm : StructPerm ⊥ →* NearLitterPerm)
 
 @[simp]
 theorem toBot_smul (f : NearLitterPerm) (x : X) : toBot f • x = f • x := by
@@ -281,102 +194,18 @@ theorem ofBot_inv_smul (f : StructPerm ⊥) (x : X) : (ofBot f)⁻¹ • x = f�
   rfl
 
 @[simp]
-theorem derivative_bot_smul {α : Λ} (f : StructPerm α) (x : X) :
-    StructPerm.derivative (nil.cons (bot_lt_coe α)) f • x = f • x :=
+theorem smul_nearLitter_fst (π : StructPerm ⊥) (N : NearLitter) : (π • N).fst = π • N.fst :=
   rfl
 
-@[simp]
-theorem smul_nearLitter_fst (π : StructPerm α) (N : NearLitter) : (π • N).fst = π • N.fst :=
-  rfl
-
-theorem smul_nearLitter_snd (π : StructPerm α) (N : NearLitter) :
-    ((π • N).2 : Set Atom) = π • (N.2 : Set Atom) :=
-  rfl
-
-theorem smul_nearLitter_coe (π : StructPerm α) (N : NearLitter) :
+theorem smul_nearLitter_coe (π : StructPerm ⊥) (N : NearLitter) :
     ((π • N) : Set Atom) = π • (N : Set Atom) :=
-  rfl
+  NearLitterPerm.smul_nearLitter_coe (ofBot π) N
+
+theorem smul_nearLitter_snd (π : StructPerm ⊥) (N : NearLitter) :
+    ((π • N).2 : Set Atom) = π • (N.2 : Set Atom) :=
+  NearLitterPerm.smul_nearLitter_snd (ofBot π) N
 
 end
-
-def protoSmul : ∀ α : TypeIndex, StructPerm α → Pretangle α → Pretangle α
-  | ⊥ => fun π t => Pretangle.toBot <| ofBot π • Pretangle.ofBot t
-  | (α : Λ) => fun π t =>
-    Pretangle.toCoe fun β (hβ : β < α) => protoSmul β (ofCoe π β hβ) '' Pretangle.ofCoe t β hβ
-termination_by protoSmul α => α
-
-instance hasSmulPretangle : ∀ α : TypeIndex, SMul (StructPerm α) (Pretangle α)
-  | α => ⟨protoSmul α⟩
-
-@[simp]
-theorem ofBot_smul_pretangle (π : StructPerm ⊥) (t : Pretangle ⊥) :
-    Pretangle.ofBot (π • t) = ofBot π • Pretangle.ofBot t := by
-  rfl
-
-@[simp]
-theorem toBot_smul_pretangle (π : NearLitterPerm) (t : Atom) :
-    Pretangle.toBot (π • t) = toBot π • Pretangle.toBot t :=
-  rfl
-
-@[simp]
-theorem ofCoe_smul_pretangle {α : Λ} (π : StructPerm α) (t : Pretangle α) :
-    Pretangle.ofCoe (π • t) = ofCoe π • Pretangle.ofCoe t := by
-  change Pretangle.ofCoe (protoSmul α π t) = ofCoe π • Pretangle.ofCoe t
-  ext β hβ : 2
-  simp only [Pi.smul_apply', PiProp.smul_apply']
-  unfold protoSmul
-  rw [Pretangle.ofCoe_toCoe]
-  rfl
-
-@[simp]
-theorem toCoe_smul_pretangle {α : Λ} (π : ∀ β : TypeIndex, β < α → StructPerm β)
-    (t : ∀ β : TypeIndex, β < α → Set (Pretangle β)) :
-    Pretangle.toCoe (π • t) = toCoe π • Pretangle.toCoe t :=
-  Pretangle.ofCoe.injective <| by
-    simp_rw [ofCoe_smul_pretangle, ofCoe_toCoe, Pretangle.ofCoe_toCoe]
-
-protected theorem one_smul : ∀ (α) (t : Pretangle α), (1 : StructPerm α) • t = t
-  | ⊥ => fun t => Pretangle.ofBot.injective <| by simp
-  | (α : Λ) => fun t =>
-    Pretangle.ofCoe.injective <| by
-      ext β hβ : 2
-      simp [← image_smul, StructPerm.one_smul β, image_id']
-termination_by one_smul α => α
-
-protected theorem mul_smul :
-    ∀ (α) (π₁ π₂ : StructPerm α) (t : Pretangle α), (π₁ * π₂) • t = π₁ • π₂ • t
-  | ⊥ => fun π₁ π₂ t => Pretangle.ofBot.injective <| by simp [mul_smul]
-  | (α : Λ) => fun π₁ π₂ t =>
-    Pretangle.ofCoe.injective <| by
-      ext β hβ : 2
-      simp only [ofCoe_smul_pretangle, ofCoe_mul, Pi.smul_apply', Pi.mul_apply,
-        PiProp.smul_apply', ← image_smul, image_image, ← StructPerm.mul_smul β]
-      rfl
-termination_by mul_smul α => α
-
-instance mulActionPretangle : MulAction (StructPerm α) (Pretangle α)
-    where
-  smul := (· • ·)
-  one_smul := StructPerm.one_smul _
-  mul_smul := StructPerm.mul_smul _
-
-theorem derivative_cons_nil (α : Λ) (f : StructPerm α) (β : TypeIndex) (hβ : β < α) :
-    derivative (cons nil hβ) f = ofCoe f β hβ := by
-      unfold derivative lower
-      dsimp only
-      rw [dif_neg hβ.ne]
-      rfl
-
-theorem ext (α : Λ) (a b : StructPerm α)
-    (h : ∀ (β : TypeIndex) (hβ : β < α), derivative (cons nil hβ) a = derivative (cons nil hβ) b) :
-    a = b :=
-  ofCoe.injective <| by
-    ext β hβ
-    simp_rw [← derivative_cons_nil]
-    exact h _ _
-
-instance : FaithfulSMul (StructPerm ⊥) Atom :=
-  ⟨fun h => ofBot.injective <| NearLitterPerm.ext <| eq_of_smul_eq_smul h⟩
 
 end StructPerm
 

--- a/ConNF/Structural/StructPerm.lean
+++ b/ConNF/Structural/StructPerm.lean
@@ -169,6 +169,13 @@ theorem derivative_mul {β} (π₁ π₂ : StructPerm α) (A : Path (α : TypeIn
     derivative A (π₁ * π₂) = derivative A π₁ * derivative A π₂ :=
   rfl
 
+@[simp]
+theorem derivative_bot (π : StructPerm α) (A : Path (α : TypeIndex) ⊥) :
+    derivative A π = toBot (π A) := by
+  funext B
+  cases path_eq_nil B
+  rfl
+
 section
 
 variable {X : Type _} [MulAction NearLitterPerm X]

--- a/ConNF/Structural/Support.lean
+++ b/ConNF/Structural/Support.lean
@@ -22,49 +22,37 @@ def SupportCondition (α : TypeIndex) : Type u :=
 noncomputable instance : Inhabited (SupportCondition α) :=
 ⟨Sum.inl default, default⟩
 
-/-- The "identity" equivalence between `(atom ⊕ near_litter) × extended_index α` and
-`support_condition α`. -/
-def toCondition : Sum Atom NearLitter × ExtendedIndex α ≃ SupportCondition α :=
-  Equiv.refl _
-
-/-- The "identity" equivalence between `support_condition α` and
-`(atom ⊕ near_litter) × extended_index α`. -/
-def ofCondition : SupportCondition α ≃ Sum Atom NearLitter × ExtendedIndex α :=
-  Equiv.refl _
-
 /-- There are `μ` support conditions. -/
 @[simp]
 theorem mk_supportCondition (α : TypeIndex) : #(SupportCondition α) = #μ := by
   simp only [SupportCondition, mk_prod, mk_sum, mk_atom, lift_id, mk_nearLitter]
   rw [add_eq_left (κ_regular.aleph0_le.trans κ_le_μ) le_rfl]
-  exact
-    mul_eq_left (κ_regular.aleph0_le.trans κ_le_μ)
-      (le_trans (mk_extendedIndex α) <| le_of_lt <| lt_trans Λ_lt_κ κ_lt_μ) (mk_ne_zero _)
+  exact mul_eq_left (κ_regular.aleph0_le.trans κ_le_μ)
+    (le_trans (mk_extendedIndex α) <| le_of_lt <| lt_trans Λ_lt_κ κ_lt_μ) (mk_ne_zero _)
 
 namespace StructPerm
 
-noncomputable instance mulActionSupportCondition :
+instance mulActionSupportCondition :
     MulAction (StructPerm α) (SupportCondition α)
     where
-  smul π c := ⟨derivative c.snd π • c.fst, c.snd⟩
-  one_smul := by
-    rintro ⟨atoms | Ns, A⟩ <;>
-    · change (_, _) = (_, _)
-      simp only [map_one, one_smul]
-  mul_smul := by
-    rintro π₁ π₂ ⟨atoms | Ns, A⟩ <;>
-    · change (_, _) = (_, _)
-      rw [derivative_mul, mul_smul]
-      rfl
-
-noncomputable instance mulActionBotSupportCondition :
-    MulAction NearLitterPerm (SupportCondition ⊥) :=
-  mulActionSupportCondition (α := ⊥)
+  smul π c := (π c.snd • c.fst, c.snd)
+  one_smul := by rintro ⟨a | N, A⟩ <;> rfl
+  mul_smul _ _ := by rintro ⟨a | N, A⟩ <;> rfl
 
 @[simp]
-theorem smul_toCondition (π : StructPerm α) (x : Sum Atom NearLitter × ExtendedIndex α) :
-    π • toCondition x = toCondition ⟨derivative x.2 π • x.1, x.2⟩ :=
+theorem smul_supportCondition {π : StructPerm α} {c : SupportCondition α} :
+    π • c = (π c.snd • c.fst, c.snd) :=
   rfl
+
+@[simp]
+theorem smul_supportCondition_eq_iff {π π' : StructPerm α} {c : SupportCondition α} :
+    π • c = π' • c ↔ π c.snd • c.fst = π' c.snd • c.fst := by
+  rw [Prod.ext_iff]
+  simp only [smul_supportCondition, and_true]
+
+-- The following attributes help with simplifications involving support conditions.
+attribute [simp] Sum.inl.injEq
+attribute [simp] Sum.inr.injEq
 
 end StructPerm
 
@@ -82,7 +70,10 @@ def Supported (x : τ) : Prop :=
 instance Support.setLike (x : τ) : SetLike (Support α G x) (SupportCondition α)
     where
   coe := Support.carrier
-  coe_injective' s t h := by cases s; cases t; congr
+  coe_injective' s t h := by
+    cases s
+    cases t
+    congr
 
 @[simp]
 theorem Support.carrier_eq_coe {x : τ} {s : Support α G x} : s.carrier = s :=

--- a/ConNF/Structural/Support.lean
+++ b/ConNF/Structural/Support.lean
@@ -44,7 +44,6 @@ instance : MulAction NearLitterPerm (SupportCondition ⊥)
   one_smul := by rintro ⟨a | N, A⟩ <;> rfl
   mul_smul _ _ := by rintro ⟨a | N, A⟩ <;> rfl
 
-@[simp]
 theorem smul_supportCondition {π : StructPerm α} {c : SupportCondition α} :
     π • c = (π c.snd • c.fst, c.snd) :=
   rfl
@@ -52,6 +51,14 @@ theorem smul_supportCondition {π : StructPerm α} {c : SupportCondition α} :
 @[simp]
 theorem smul_supportCondition_eq_iff {π π' : StructPerm α} {c : SupportCondition α} :
     π • c = π' • c ↔ π c.snd • c.fst = π' c.snd • c.fst := by
+  rw [Prod.ext_iff]
+  simp only [smul_supportCondition, and_true]
+
+@[simp]
+theorem smul_supportCondition_eq_iff' {π π' : StructPerm α}
+    {x y : Atom ⊕ NearLitter} {A : ExtendedIndex α} :
+    π • (show SupportCondition α from (x, A)) = π' • (show SupportCondition α from (y, A)) ↔
+    π A • x = π' A • y := by
   rw [Prod.ext_iff]
   simp only [smul_supportCondition, and_true]
 

--- a/ConNF/Structural/Support.lean
+++ b/ConNF/Structural/Support.lean
@@ -32,10 +32,15 @@ theorem mk_supportCondition (α : TypeIndex) : #(SupportCondition α) = #μ := b
 
 namespace StructPerm
 
-instance mulActionSupportCondition :
-    MulAction (StructPerm α) (SupportCondition α)
+instance : MulAction (StructPerm α) (SupportCondition α)
     where
   smul π c := (π c.snd • c.fst, c.snd)
+  one_smul := by rintro ⟨a | N, A⟩ <;> rfl
+  mul_smul _ _ := by rintro ⟨a | N, A⟩ <;> rfl
+
+instance : MulAction NearLitterPerm (SupportCondition ⊥)
+    where
+  smul π c := (π • c.fst, c.snd)
   one_smul := by rintro ⟨a | N, A⟩ <;> rfl
   mul_smul _ _ := by rintro ⟨a | N, A⟩ <;> rfl
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,5 @@
 - Remove excessive imports.
+- Maybe remove `localCardinal`.
 - Refactor new allowable permutation to use a `smul_fuzz` definition.
 - Fix variable letters.
 - Add typeclasses for derivatives and toStructPerm?

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,6 @@
 - Remove excessive imports.
 - Maybe remove `localCardinal`.
+- Clean up instances to take advantage of Lean 4.
 - Refactor new allowable permutation to use a `smul_fuzz` definition.
 - Fix variable letters.
 - Add typeclasses for derivatives and toStructPerm?

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,7 @@
 - Remove excessive imports.
 - Maybe remove `localCardinal`.
 - Clean up instances to take advantage of Lean 4.
+- Exploit `erw` where possible.
 - Refactor new allowable permutation to use a `smul_fuzz` definition.
 - Fix variable letters.
 - Add typeclasses for derivatives and toStructPerm?


### PR DESCRIPTION
Structural permutations are now function types from `ExtendedIndex` to `NearLitterPerm`. This makes derivatives easier to work with, but pretangles harder to work with. This is fine, because we never used pretangles anyway. Along the way we also make changes to the way we work with support conditions.