### PR TITLE
Swap elements of support conditions

### DIFF
--- a/ConNF/Foa/Action/Refine.lean
+++ b/ConNF/Foa/Action/Refine.lean
@@ -84,11 +84,6 @@ theorem refine_litterMap {A : ExtendedIndex β} :
 
 theorem refine_precise : Precise (φ.refine hφ) := fun _ => NearLitterAction.refine_precise
 
-theorem refineSupports {α : Λ} [BasePositions] [Phase2Assumptions α] {β : Iio α} {t : Tangle β}
-    (φ : StructAction β) (hφ : φ.Lawful) (h : φ.Supports t) : (φ.refine hφ).Supports t :=
-  { atom_mem := fun a B ha => Or.inl (Or.inl <| h.atom_mem a B ha)
-    litter_mem := h.litter_mem }
-
 end StructAction
 
 namespace StructAction

--- a/ConNF/Foa/Action/StructAction.lean
+++ b/ConNF/Foa/Action/StructAction.lean
@@ -78,13 +78,6 @@ end Precise
 
 variable {α : Λ} [BasePositions] [Phase2Assumptions α] {β : Iio α}
 
-/-- A structural action *supports* a tangle if it defines an image for everything
-in the reduction of its designated support. -/
-structure Supports (φ : StructAction β) (t : Tangle β) : Prop where
-  atom_mem : ∀ a B, (inl a, B) ∈ reducedSupport α t → ((φ B).atomMap a).Dom
-  litter_mem :
-    ∀ (L : Litter) (B), (inr L.toNearLitter, B) ∈ reducedSupport α t → ((φ B).litterMap L).Dom
-
 instance {β : TypeIndex} : PartialOrder (StructAction β)
     where
   le φ ψ := ∀ B, φ B ≤ ψ B

--- a/ConNF/Foa/Basic/Approximation.lean
+++ b/ConNF/Foa/Basic/Approximation.lean
@@ -427,8 +427,8 @@ theorem ExactlyApproximates.comp {β γ : TypeIndex} {π₀ : StructApprox β} {
 /-- The inductive hypothesis used to construct the induced action of an approximation in the
 freedom of action theorem. -/
 structure Hypothesis {β : Iic α} (c : SupportCondition β) where
-  atomImage : ∀ A a, ⟨inl a, A⟩ <[α] c → Atom
-  nearLitterImage : ∀ A N, ⟨inr N, A⟩ <[α] c → NearLitter
+  atomImage : ∀ A a, (A, inl a) <[α] c → Atom
+  nearLitterImage : ∀ A N, (A, inr N) <[α] c → NearLitter
 
 namespace Hypothesis
 
@@ -436,8 +436,8 @@ variable {β : Iic α}
 
 def fixMap :
     PSum (Σ' _ : ExtendedIndex β, Atom) (Σ' _ : ExtendedIndex β, NearLitter) → SupportCondition β
-  | PSum.inl ⟨A, a⟩ => ⟨inl a, A⟩
-  | PSum.inr ⟨A, N⟩ => ⟨inr N, A⟩
+  | PSum.inl ⟨A, a⟩ => (A, inl a)
+  | PSum.inr ⟨A, N⟩ => (A, inr N)
 
 def fixWf :
     WellFoundedRelation
@@ -448,14 +448,14 @@ def fixWf :
 mutual
   /-- Construct the fixed-point functions `fix_atom` and `fix_near_litter`.
   This is used to compute the induced action of an approximation on all atoms and near-litters. -/
-  noncomputable def fixAtom (Fa : ∀ (A : ExtendedIndex β) (a), Hypothesis ⟨inl a, A⟩ → Atom)
-      (FN : ∀ (A : ExtendedIndex β) (N), Hypothesis ⟨inr N, A⟩ → NearLitter) :
+  noncomputable def fixAtom (Fa : ∀ (A : ExtendedIndex β) (a), Hypothesis (A, inl a) → Atom)
+      (FN : ∀ (A : ExtendedIndex β) (N), Hypothesis (A, inr N) → NearLitter) :
       ExtendedIndex β → Atom → Atom
     | A, a => Fa A a ⟨fun B b _ => fixAtom Fa FN B b, fun B N _ => fixNearLitter Fa FN B N⟩
   /-- Construct the fixed-point functions `fix_atom` and `fix_near_litter`.
   This is used to compute the induced action of an approximation on all atoms and near-litters. -/
-  noncomputable def fixNearLitter (Fa : ∀ (A : ExtendedIndex β) (a), Hypothesis ⟨inl a, A⟩ → Atom)
-      (FN : ∀ (A : ExtendedIndex β) (N), Hypothesis ⟨inr N, A⟩ → NearLitter) :
+  noncomputable def fixNearLitter (Fa : ∀ (A : ExtendedIndex β) (a), Hypothesis (A, inl a) → Atom)
+      (FN : ∀ (A : ExtendedIndex β) (N), Hypothesis (A, inr N) → NearLitter) :
       ExtendedIndex β → NearLitter → NearLitter
     | A, N => FN A N ⟨fun B b _ => fixAtom Fa FN B b, fun B N _ => fixNearLitter Fa FN B N⟩
 end

--- a/ConNF/Foa/Basic/Hypotheses.lean
+++ b/ConNF/Foa/Basic/Hypotheses.lean
@@ -33,9 +33,10 @@ class PositionedTypedObjects [TangleData α] [TypedObjects α] [PositionFunction
   typedAtomPosition_eq : ∀ a : Atom, position (typedAtom a : Tangle α) = typedAtomPosition a
   typedNearLitterPosition_eq :
     ∀ N : NearLitter, position (typedNearLitter N : Tangle α) = typedNearLitterPosition N
+  -- TODO: Refactor this condition to avoid the `elim`.
   support_le :
     ∀ (t : Tangle α) (c : SupportCondition α),
-      c ∈ designatedSupport t → c.fst.elim typedAtomPosition typedNearLitterPosition ≤ position t
+      c ∈ designatedSupport t → c.snd.elim typedAtomPosition typedNearLitterPosition ≤ position t
 
 /-- For all tangles `t` that are not typed singletons and not typed litters, `t` comes later than
 all of the support conditions in its designated support. That is, if an atom `a` is in the

--- a/ConNF/Foa/Basic/Reduction.lean
+++ b/ConNF/Foa/Basic/Reduction.lean
@@ -18,8 +18,8 @@ variable {β : Λ} {G : Type _} {τ : Type _} [SMul G (SupportCondition β)] [SM
 /-- A support condition is *reduced* if it is an atom or a litter. -/
 @[mk_iff]
 inductive Reduced {β : TypeIndex} : SupportCondition β → Prop
-  | mkAtom (a : Atom) (B : ExtendedIndex β) : Reduced (inl a, B)
-  | mkLitter (L : Litter) (B : ExtendedIndex β) : Reduced (inr L.toNearLitter, B)
+  | mkAtom (B : ExtendedIndex β) (a : Atom) : Reduced (B, inl a)
+  | mkLitter (B : ExtendedIndex β) (L : Litter) : Reduced (B, inr L.toNearLitter)
 
 /-- The *reduction* of a set of support conditions is the downward closure of the set under
 the constrains relation, but we only keep reduced conditions. -/
@@ -121,22 +121,22 @@ theorem reduction_designatedSupport_supports [TangleData β] (t : Tangle β) :
   intro π h₁
   refine' (designatedSupport t).supports π _
   rintro ⟨B, a | N⟩ h₂
-  · exact h₁ (mem_reduction_of_reduced α _ _ (Reduced.mkAtom a B) h₂)
+  · exact h₁ (mem_reduction_of_reduced α _ _ (Reduced.mkAtom B a) h₂)
   · by_cases N.IsLitter
     · obtain ⟨L, rfl⟩ := h.exists_litter_eq
-      exact h₁ (mem_reduction_of_reduced α _ _ (Reduced.mkLitter L B) h₂)
+      exact h₁ (mem_reduction_of_reduced α _ _ (Reduced.mkLitter B L) h₂)
     · have h := NearLitter.not_isLitter h
       have h₃ :=
-        congr_arg Prod.fst
+        congr_arg Prod.snd
           (h₁
-            (mem_reduction_of_reduced_constrains α _ _ _ (Reduced.mkLitter N.fst B)
+            (mem_reduction_of_reduced_constrains α _ _ _ (Reduced.mkLitter B N.fst)
               (Constrains.nearLitter N h B) h₂))
       have h₄ := fun a ha =>
-        congr_arg Prod.fst
+        congr_arg Prod.snd
           (h₁
-            (mem_reduction_of_reduced_constrains α _ _ _ (Reduced.mkAtom a B)
+            (mem_reduction_of_reduced_constrains α _ _ _ (Reduced.mkAtom B a)
               (Constrains.symmDiff N a ha B) h₂))
-      refine' Prod.ext _ rfl
+      refine' Prod.ext rfl _
       change inr _ = inr _ at h₃
       change ∀ a ha, inl _ = inl _ at h₄
       change inr _ = inr _
@@ -169,9 +169,9 @@ theorem mem_reducedSupport_iff [TangleData β] (t : Tangle β) (c : SupportCondi
 theorem mem_reduction_designated_support {β γ : Iic α} {δ ε : Iio α} (hδ : (δ : Λ) < γ)
     (hε : (ε : Λ) < γ) (hδε : δ ≠ ε) (B : Path (β : TypeIndex) γ) (t : Tangle δ)
     (c : SupportCondition δ) (h : c ∈ reducedSupport α t) :
-    (c.fst, (B.cons (coe_lt hδ)).comp c.snd) <[α]
-      (inr (fuzz (coe_ne_coe.mpr <| coe_ne' hδε) t).toNearLitter,
-        (B.cons (coe_lt hε)).cons (bot_lt_coe _)) := by
+    ((B.cons (coe_lt hδ)).comp c.fst, c.snd) <[α]
+      ((B.cons (coe_lt hε)).cons (bot_lt_coe _),
+        inr (fuzz (coe_ne_coe.mpr <| coe_ne' hδε) t).toNearLitter) := by
   obtain ⟨⟨d, hd, hcd⟩, _⟩ := h
   refine' Relation.TransGen.tail' _ (Constrains.fuzz hδ hε hδε B t d hd)
   exact reflTransGen_constrains_comp hcd _

--- a/ConNF/Foa/Basic/Reduction.lean
+++ b/ConNF/Foa/Basic/Reduction.lean
@@ -120,7 +120,7 @@ theorem reduction_designatedSupport_supports [TangleData β] (t : Tangle β) :
     Supports (Allowable β) (reduction α (designatedSupport t : Set (SupportCondition β))) t := by
   intro π h₁
   refine' (designatedSupport t).supports π _
-  rintro ⟨a | N, B⟩ h₂
+  rintro ⟨B, a | N⟩ h₂
   · exact h₁ (mem_reduction_of_reduced α _ _ (Reduced.mkAtom a B) h₂)
   · by_cases N.IsLitter
     · obtain ⟨L, rfl⟩ := h.exists_litter_eq

--- a/ConNF/Foa/Complete/AtomCompletion.lean
+++ b/ConNF/Foa/Complete/AtomCompletion.lean
@@ -25,7 +25,7 @@ theorem equiv_apply_eq {S T U V : Sublitter} {a b}
   exact (equiv_apply_mem (T.subset h.choose)).symm
 
 /-- Computes the action of a structural approximation `π` on an atom `a`. -/
-noncomputable def atomCompletion (A : ExtendedIndex β) (a : Atom) (H : Hypothesis ⟨inl a, A⟩) :
+noncomputable def atomCompletion (A : ExtendedIndex β) (a : Atom) (H : Hypothesis (A, inl a)) :
     Atom :=
   if h : a ∈ (π A).atomPerm.domain then π A • a
   else

--- a/ConNF/Foa/Complete/CompleteAction.lean
+++ b/ConNF/Foa/Complete/CompleteAction.lean
@@ -64,21 +64,21 @@ theorem completeNearLitterMap_fst_eq' :
   rfl
 
 @[simp]
-theorem foaHypothesis_atomImage {c : SupportCondition β} (h : (inl a, A) <[α] c) :
+theorem foaHypothesis_atomImage {c : SupportCondition β} (h : (A, inl a) <[α] c) :
     (π.foaHypothesis : Hypothesis c).atomImage A a h = π.completeAtomMap A a :=
   rfl
 
 @[simp]
-theorem foaHypothesis_nearLitterImage {c : SupportCondition β} (h : (inr N, A) <[α] c) :
+theorem foaHypothesis_nearLitterImage {c : SupportCondition β} (h : (A, inr N) <[α] c) :
     (π.foaHypothesis : Hypothesis c).nearLitterImage A N h = π.completeNearLitterMap A N :=
   rfl
 
 end MapSpec
 
-theorem completeAtomMap_eq_of_mem_domain {a} {A} (h : a ∈ (π A).atomPerm.domain) :
+theorem completeAtomMap_eq_of_mem_domain {A} {a} (h : a ∈ (π A).atomPerm.domain) :
     π.completeAtomMap A a = π A • a := by rw [completeAtomMap_eq, atomCompletion, dif_pos h]
 
-theorem completeAtomMap_eq_of_not_mem_domain {a} {A} (h : a ∉ (π A).atomPerm.domain) :
+theorem completeAtomMap_eq_of_not_mem_domain {A} {a} (h : a ∉ (π A).atomPerm.domain) :
     π.completeAtomMap A a =
       ((π A).largestSublitter a.1).equiv ((π A).largestSublitter (π.completeLitterMap A a.1))
         ⟨a, (π A).mem_largestSublitter_of_not_mem_domain a h⟩ := by
@@ -95,7 +95,7 @@ theorem completeLitterMap_eq_of_inflexibleCoe {A : ExtendedIndex β} {L : Litter
     (h : InflexibleCoe L A) (h₁ h₂) :
     π.completeLitterMap A L =
       fuzz (WithBot.coe_ne_coe.mpr <| coe_ne' h.hδε)
-        ((ihAction (π.foaHypothesis : Hypothesis ⟨inr L.toNearLitter, A⟩)).hypothesisedAllowable h
+        ((ihAction (π.foaHypothesis : Hypothesis (A, inr L.toNearLitter))).hypothesisedAllowable h
             h₁ h₂ •
           h.t) := by
   rw [completeLitterMap_eq, litterCompletion_of_inflexibleCoe]
@@ -105,7 +105,7 @@ theorem completeLitterMap_eq_of_inflexible_coe' {A : ExtendedIndex β} {L : Litt
     π.completeLitterMap A L =
       if h' : _ ∧ _ then
         fuzz (WithBot.coe_ne_coe.mpr <| coe_ne' h.hδε)
-          ((ihAction (π.foaHypothesis : Hypothesis ⟨inr L.toNearLitter, A⟩)).hypothesisedAllowable h
+          ((ihAction (π.foaHypothesis : Hypothesis (A, inr L.toNearLitter))).hypothesisedAllowable h
               h'.1 h'.2 •
             h.t)
       else L := by

--- a/ConNF/Foa/Complete/LitterCompletion.lean
+++ b/ConNF/Foa/Complete/LitterCompletion.lean
@@ -144,32 +144,32 @@ theorem InflexibleBot.comp_B (h : InflexibleBot L B) (A : Path (β : TypeIndex) 
 
 end Comp
 
-theorem InflexibleBot.constrains {β : Iic α} {L : Litter} {A : ExtendedIndex β}
-    (h : InflexibleBot L A) : (inl h.a, h.B.cons (bot_lt_coe _)) <[α] (inr L.toNearLitter, A) := by
+theorem InflexibleBot.constrains {β : Iic α} {A : ExtendedIndex β} {L : Litter}
+    (h : InflexibleBot L A) : (h.B.cons (bot_lt_coe _), inl h.a) <[α] (A, inr L.toNearLitter) := by
   have := Constrains.fuzz_bot h.hε h.B h.a
   rw [← h.hL, ← h.hA] at this
   exact Relation.TransGen.single this
 
-theorem inflexible_of_inflexibleBot {β : Iic α} {L : Litter} {A : ExtendedIndex β}
+theorem inflexible_of_inflexibleBot {β : Iic α} {A : ExtendedIndex β} {L : Litter}
     (h : InflexibleBot L A) : Inflexible α L A := by
   have := Inflexible.mk_bot h.hε h.B h.a
   rw [← h.hL, ← h.hA] at this
   exact this
 
-theorem inflexible_of_inflexibleCoe {β : Iic α} {L : Litter} {A : ExtendedIndex β}
+theorem inflexible_of_inflexibleCoe {β : Iic α} {A : ExtendedIndex β} {L : Litter}
     (h : InflexibleCoe L A) : Inflexible α L A := by
   have := Inflexible.mk_coe h.hδ h.hε h.hδε h.B h.t
   rw [← h.hL, ← h.hA] at this
   exact this
 
-theorem inflexibleBot_or_inflexibleCoe_of_inflexible {β : Iic α} {L : Litter} {A : ExtendedIndex β}
+theorem inflexibleBot_or_inflexibleCoe_of_inflexible {β : Iic α} {A : ExtendedIndex β} {L : Litter}
     (h : Inflexible α L A) : Nonempty (InflexibleBot L A) ∨ Nonempty (InflexibleCoe L A) := by
   obtain ⟨hδ, hε, hδε, B, t⟩ | ⟨hε, B, a⟩ := h
   · refine' Or.inr ⟨⟨_, _, _, _, _, _, _, _, rfl, rfl⟩⟩ <;> assumption
   · refine' Or.inl ⟨⟨_, _, _, _, _, rfl, rfl⟩⟩; assumption
 
-theorem inflexible_iff_inflexibleBot_or_inflexibleCoe {β : Iic α} {L : Litter}
-    {A : ExtendedIndex β} :
+theorem inflexible_iff_inflexibleBot_or_inflexibleCoe {β : Iic α} {A : ExtendedIndex β}
+    {L : Litter} :
     Inflexible α L A ↔ Nonempty (InflexibleBot L A) ∨ Nonempty (InflexibleCoe L A) := by
   constructor
   exact inflexibleBot_or_inflexibleCoe_of_inflexible
@@ -177,8 +177,8 @@ theorem inflexible_iff_inflexibleBot_or_inflexibleCoe {β : Iic α} {L : Litter}
   exact inflexible_of_inflexibleBot h
   exact inflexible_of_inflexibleCoe h
 
-theorem flexible_iff_not_inflexibleBot_inflexibleCoe {β : Iic α} {L : Litter}
-    {A : ExtendedIndex β} :
+theorem flexible_iff_not_inflexibleBot_inflexibleCoe {β : Iic α} {A : ExtendedIndex β}
+    {L : Litter} :
     Flexible α L A ↔ IsEmpty (InflexibleBot L A) ∧ IsEmpty (InflexibleCoe L A) := by
   constructor
   · intro h
@@ -189,7 +189,7 @@ theorem flexible_iff_not_inflexibleBot_inflexibleCoe {β : Iic α} {L : Litter}
     · exact h₁.1.false h.some
     · exact h₁.2.false h.some
 
-theorem flexible_cases' (β : Iic α) (L : Litter) (A : ExtendedIndex β) :
+theorem flexible_cases' (β : Iic α) (A : ExtendedIndex β) (L : Litter) :
     Flexible α L A ∨ Nonempty (InflexibleBot L A) ∨ Nonempty (InflexibleCoe L A) := by
   rw [← inflexible_iff_inflexibleBot_or_inflexibleCoe, or_comm]
   exact flexible_cases α L A
@@ -207,19 +207,19 @@ def ihAction {β : Iic α} {c : SupportCondition β} (H : Hypothesis c) : Struct
       simp only [PFun.dom_mk]
       have := reduction_small'' α (small_singleton c)
       simp only [mem_singleton_iff, exists_prop, exists_eq_left] at this
-      refine' Small.image_subset (fun a => (inl a, B)) _ this _
+      refine' Small.image_subset (fun a => (B, inl a)) _ this _
       · intro a b h
-        simpa only [Prod.mk.injEq, inl.injEq, and_true] using h
+        simpa [Prod.mk.injEq, inl.injEq, true_and] using h
       · rintro _ ⟨a, h, rfl⟩
         exact h
     litterMap_dom_small := by
       simp only [PFun.dom_mk]
       have := reduction_small'' α (small_singleton c)
       simp only [mem_singleton_iff, exists_prop, exists_eq_left] at this
-      refine' Small.image_subset (fun L => (inr L.toNearLitter, B)) _ this _
+      refine' Small.image_subset (fun L => (B, inr L.toNearLitter)) _ this _
       · intro L₁ L₂ h
         simpa only [Prod.mk.injEq, inr.injEq, Litter.toNearLitter_injective.eq_iff,
-          and_true] using h
+          true_and] using h
       · rintro _ ⟨a, h, rfl⟩
         exact h }
 
@@ -272,7 +272,7 @@ theorem _root_.ConNF.StructAction.hypothesisedAllowable_exactlyApproximates (φ 
   (φ.comp (h.B.cons (coe_lt h.hδ))).allowable_exactlyApproximates _ _ _
 
 noncomputable def litterCompletion (π : StructApprox β) (A : ExtendedIndex β) (L : Litter)
-    (H : Hypothesis ⟨inr L.toNearLitter, A⟩) : Litter :=
+    (H : Hypothesis (A, inr L.toNearLitter)) : Litter :=
   if h : Nonempty (InflexibleCoe L A) then
     if hs : _ ∧ _ then
       fuzz (coe_ne_coe.mpr <| coe_ne' h.some.hδε)
@@ -285,7 +285,7 @@ noncomputable def litterCompletion (π : StructApprox β) (A : ExtendedIndex β)
     else NearLitterApprox.flexibleCompletion α (π A) A • L
 
 theorem litterCompletion_of_flexible (π : StructApprox β) (A : ExtendedIndex β) (L : Litter)
-    (H : Hypothesis ⟨inr L.toNearLitter, A⟩) (hflex : Flexible α L A) :
+    (H : Hypothesis (A, inr L.toNearLitter)) (hflex : Flexible α L A) :
     litterCompletion π A L H = NearLitterApprox.flexibleCompletion α (π A) A • L := by
   rw [litterCompletion, dif_neg, dif_neg]
   · rintro ⟨⟨γ, ε, hε, C, a, rfl, rfl⟩⟩
@@ -294,7 +294,7 @@ theorem litterCompletion_of_flexible (π : StructApprox β) (A : ExtendedIndex �
     exact hflex (Inflexible.mk_coe hδ hε hδε _ _)
 
 theorem litterCompletion_of_inflexibleCoe' (π : StructApprox β) (A : ExtendedIndex β) (L : Litter)
-    (H : Hypothesis ⟨inr L.toNearLitter, A⟩) (h : InflexibleCoe L A) :
+    (H : Hypothesis (A, inr L.toNearLitter)) (h : InflexibleCoe L A) :
     litterCompletion π A L H =
       if h' : _ ∧ _ then
         fuzz (coe_ne_coe.mpr <| coe_ne' h.hδε)
@@ -309,7 +309,7 @@ theorem litterCompletion_of_inflexibleCoe' (π : StructApprox β) (A : ExtendedI
   rfl
 
 theorem litterCompletion_of_inflexibleCoe (π : StructApprox β) (A : ExtendedIndex β) (L : Litter)
-    (H : Hypothesis ⟨inr L.toNearLitter, A⟩) (h : InflexibleCoe L A)
+    (H : Hypothesis (A, inr L.toNearLitter)) (h : InflexibleCoe L A)
     (h₁ : ((ihAction H).comp (h.B.cons (coe_lt h.hδ))).Lawful)
     (h₂ : ((ihAction H).comp (h.B.cons (coe_lt h.hδ))).MapFlexible) :
     litterCompletion π A L H =
@@ -323,7 +323,7 @@ theorem litterCompletion_of_inflexibleCoe (π : StructApprox β) (A : ExtendedIn
       exact h₂
 
 theorem litterCompletion_of_inflexibleBot (π : StructApprox β) (A : ExtendedIndex β) (L : Litter)
-    (H : Hypothesis ⟨inr L.toNearLitter, A⟩) (h : InflexibleBot L A) :
+    (H : Hypothesis (A, inr L.toNearLitter)) (h : InflexibleBot L A) :
     litterCompletion π A L H =
       fuzz (show (⊥ : TypeIndex) ≠ (h.ε : Λ) from bot_ne_coe)
         (H.atomImage (h.B.cons (bot_lt_coe _)) h.a h.constrains) := by

--- a/ConNF/Foa/Complete/NearLitterCompletion.lean
+++ b/ConNF/Foa/Complete/NearLitterCompletion.lean
@@ -13,8 +13,8 @@ namespace StructApprox
 variable [Params.{u}] {α : Λ} [BasePositions] [Phase2Assumptions α] {β : Iic α}
   [FreedomOfActionHypothesis β]
 
-def nearLitterHypothesis (A : ExtendedIndex β) (N : NearLitter) (H : Hypothesis ⟨inr N, A⟩) :
-    Hypothesis ⟨inr N.1.toNearLitter, A⟩
+def nearLitterHypothesis (A : ExtendedIndex β) (N : NearLitter) (H : Hypothesis (A, inr N)) :
+    Hypothesis (A, inr N.1.toNearLitter)
     where
   atomImage B a h :=
     H.atomImage B a
@@ -34,14 +34,14 @@ def nearLitterHypothesis (A : ExtendedIndex β) (N : NearLitter) (H : Hypothesis
         exact Relation.TransGen.tail h (Constrains.nearLitter N h' A))
 
 def nearLitterCompletionMap (π : StructApprox β) (A : ExtendedIndex β) (N : NearLitter)
-    (H : Hypothesis ⟨inr N, A⟩) : Set Atom :=
+    (H : Hypothesis (A, inr N)) : Set Atom :=
   (NearLitterApprox.largestSublitter (π A) (π.litterCompletion A N.1 (nearLitterHypothesis A N H)) ∪
       π A • ((N : Set Atom) ∩ (π A).atomPerm.domain)) ∆
     ⋃ (a : Atom) (ha : a ∈ litterSet N.1 ∆ N \ (π A).atomPerm.domain),
       {H.atomImage A a (Relation.TransGen.single (Constrains.symmDiff N a ha.1 A))}
 
 theorem nearLitterCompletionMap_isNearLitter (π : StructApprox β) (A : ExtendedIndex β)
-    (N : NearLitter) (H : Hypothesis ⟨inr N, A⟩) :
+    (N : NearLitter) (H : Hypothesis (A, inr N)) :
     IsNearLitter (π.litterCompletion A N.fst (nearLitterHypothesis A N H))
       (π.nearLitterCompletionMap A N H) := by
   rw [nearLitterCompletionMap, IsNearLitter, IsNear, NearLitterApprox.coe_largestSublitter,
@@ -53,13 +53,13 @@ theorem nearLitterCompletionMap_isNearLitter (π : StructApprox β) (A : Extende
   · exact Small.bUnion (Small.mono (diff_subset _ _) N.2.prop) fun _ _ => small_singleton _
 
 noncomputable def nearLitterCompletion (π : StructApprox β) (A : ExtendedIndex β) (N : NearLitter)
-    (H : Hypothesis ⟨inr N, A⟩) : NearLitter :=
+    (H : Hypothesis (A, inr N)) : NearLitter :=
   ⟨litterCompletion π A N.1 (nearLitterHypothesis A N H), nearLitterCompletionMap π A N H,
     nearLitterCompletionMap_isNearLitter π A N H⟩
 
 @[simp]
 theorem nearLitterCompletion_fst_eq (π : StructApprox β) (A : ExtendedIndex β) (N : NearLitter)
-    (H : Hypothesis ⟨inr N, A⟩) :
+    (H : Hypothesis (A, inr N)) :
     (π.nearLitterCompletion A N H).1 = litterCompletion π A N.1 (nearLitterHypothesis A N H) :=
   rfl
 

--- a/ConNF/Foa/Properties/ConstrainedAction.lean
+++ b/ConNF/Foa/Properties/ConstrainedAction.lean
@@ -314,24 +314,6 @@ theorem ihAction_le {π : StructApprox β} {c d : SupportCondition β} (h : c �
   · intro a ha
     exact Relation.TransGen.trans_left ha h
 
-theorem ihActionSupports {π : StructApprox β} {A : ExtendedIndex β} {L : Litter}
-    (h : InflexibleCoe L A) :
-    ((ihAction (π.foaHypothesis : Hypothesis (inr L.toNearLitter, A))).comp
-      (h.B.cons (coe_lt h.hδ))).Supports h.t
-    where
-  atom_mem := by
-    intro a B ha
-    simp only [StructAction.comp_apply, ihAction_atomMap]
-    have := mem_reduction_designated_support α h.hδ h.hε h.hδε h.B h.t _ ha
-    rw [← h.hL, ← h.hA] at this
-    exact this
-  litter_mem := by
-    intro L B hL
-    simp only [StructAction.comp_apply, ihAction_litterMap]
-    have := mem_reduction_designated_support α h.hδ h.hε h.hδε h.B h.t _ hL
-    rw [← h.hL, ← h.hA] at this
-    exact this
-
 theorem transGen_constrains_of_mem_designatedSupport {A : ExtendedIndex β} {L : Litter}
     {h : InflexibleCoe L A} {γ : Iic α} {δ ε : Iio α} {hδ : (δ : Λ) < γ} {hε : (ε : Λ) < γ}
     (hδε : δ ≠ ε) {C : Path (h.δ : TypeIndex) γ} {t : Tangle δ} {d : SupportCondition h.δ}

--- a/ConNF/Foa/Properties/ConstrainedAction.lean
+++ b/ConNF/Foa/Properties/ConstrainedAction.lean
@@ -73,38 +73,38 @@ theorem transConstrained_of_reflTransConstrained_of_constrains {c d e f : Suppor
   transConstrained_of_reflTransConstrained_of_trans_constrains he (Relation.TransGen.single hf)
 
 theorem fst_transConstrained {c d : SupportCondition β} {A : ExtendedIndex β} {a : Atom}
-    (hac : (inl a, A) ∈ reflTransConstrained c d) :
-    (inr a.fst.toNearLitter, A) ∈ transConstrained c d :=
+    (hac : (A, inl a) ∈ reflTransConstrained c d) :
+    (A, inr a.fst.toNearLitter) ∈ transConstrained c d :=
   transConstrained_of_reflTransConstrained_of_constrains hac (Constrains.atom a A)
 
 theorem fst_mem_trans_constrained' {c d : SupportCondition β} {A : ExtendedIndex β} {a : Atom}
-    (h : (inl a, A) ∈ transConstrained c d) :
-  (inr a.fst.toNearLitter, A) ∈ transConstrained c d :=
+    (h : (A, inl a) ∈ transConstrained c d) :
+    (A, inr a.fst.toNearLitter) ∈ transConstrained c d :=
   transConstrained_of_constrains h (Constrains.atom a A)
 
 theorem fst_mem_transConstrained {c d : SupportCondition β} {A : ExtendedIndex β} {N : NearLitter}
-    (hN : (inr N, A) ∈ transConstrained c d) :
-  (inr N.fst.toNearLitter, A) ∈ transConstrained c d := by
+    (hN : (A, inr N) ∈ transConstrained c d) :
+    (A, inr N.fst.toNearLitter) ∈ transConstrained c d := by
   obtain hN | hN := hN
   exact Or.inl (transGen_nearLitter' hN)
   exact Or.inr (transGen_nearLitter' hN)
 
 theorem fst_mem_refl_trans_constrained' {c d : SupportCondition β} {A : ExtendedIndex β} {a : Atom}
-    (h : (inl a, A) ∈ reflTransConstrained c d) :
-    (inr a.fst.toNearLitter, A) ∈ reflTransConstrained c d :=
+    (h : (A, inl a) ∈ reflTransConstrained c d) :
+    (A, inr a.fst.toNearLitter) ∈ reflTransConstrained c d :=
   reflTransConstrained_of_constrains h (Constrains.atom a A)
 
 theorem fst_mem_reflTransConstrained {c d : SupportCondition β} {A : ExtendedIndex β}
-    {N : NearLitter} (hN : (inr N, A) ∈ reflTransConstrained c d) :
-    (inr N.fst.toNearLitter, A) ∈ reflTransConstrained c d := by
+    {N : NearLitter} (hN : (A, inr N) ∈ reflTransConstrained c d) :
+    (A, inr N.fst.toNearLitter) ∈ reflTransConstrained c d := by
   obtain hN | hN := hN
   exact Or.inl (reflTransGen_nearLitter hN)
   exact Or.inr (reflTransGen_nearLitter hN)
 
 theorem fst_mem_transConstrained_of_mem_symmDiff {c d : SupportCondition β} {A : ExtendedIndex β}
     {N : NearLitter} {a : Atom} (h : a ∈ litterSet N.1 ∆ N)
-    (hN : (inr N, A) ∈ transConstrained c d) :
-    (inr a.fst.toNearLitter, A) ∈ transConstrained c d := by
+    (hN : (A, inr N) ∈ transConstrained c d) :
+    (A, inr a.fst.toNearLitter) ∈ transConstrained c d := by
   obtain ⟨h₁, h₂⟩ | ⟨h₁, h₂⟩ := h
   · rw [mem_litterSet] at h₁
     rw [h₁]
@@ -117,8 +117,8 @@ theorem fst_mem_transConstrained_of_mem_symmDiff {c d : SupportCondition β} {A 
 
 theorem fst_mem_reflTransConstrained_of_mem_symmDiff {c d : SupportCondition β}
     {A : ExtendedIndex β} {N : NearLitter} {a : Atom} (h : a ∈ litterSet N.1 ∆ N)
-    (hN : (inr N, A) ∈ reflTransConstrained c d) :
-    (inr a.fst.toNearLitter, A) ∈ reflTransConstrained c d := by
+    (hN : (A, inr N) ∈ reflTransConstrained c d) :
+    (A, inr a.fst.toNearLitter) ∈ reflTransConstrained c d := by
   obtain ⟨h₁, h₂⟩ | ⟨h₁, h₂⟩ := h
   · rw [mem_litterSet] at h₁
     rw [h₁]
@@ -130,8 +130,8 @@ theorem fst_mem_reflTransConstrained_of_mem_symmDiff {c d : SupportCondition β}
       exact Relation.ReflTransGen.head (Constrains.symmDiff N a (Or.inr ⟨h₁, h₂⟩) A) hN
 
 theorem fst_mem_transConstrained_of_mem {c d : SupportCondition β} {A : ExtendedIndex β}
-    {N : NearLitter} {a : Atom} (h : a ∈ N) (hN : (inr N, A) ∈ transConstrained c d) :
-    (inr a.fst.toNearLitter, A) ∈ transConstrained c d := by
+    {N : NearLitter} {a : Atom} (h : a ∈ N) (hN : (A, inr N) ∈ transConstrained c d) :
+    (A, inr a.fst.toNearLitter) ∈ transConstrained c d := by
   by_cases ha : a.1 = N.1
   · rw [ha]
     exact fst_mem_transConstrained hN
@@ -148,20 +148,20 @@ theorem eq_of_sublitter_bijection_apply_eq {π : NearLitterApprox} {L₁ L₂ L�
 noncomputable def constrainedAction (π : StructApprox β) (s : Set (SupportCondition β))
     (hs : Small s) : StructAction β := fun B =>
   { atomMap := fun a =>
-      ⟨∃ c : SupportCondition β, c ∈ s ∧ (inl a, B) ≤[α] c,
+      ⟨∃ c : SupportCondition β, c ∈ s ∧ (B, inl a) ≤[α] c,
         fun _ => π.completeAtomMap B a⟩
     litterMap := fun L =>
-      ⟨∃ c : SupportCondition β, c ∈ s ∧ (inr L.toNearLitter, B) ≤[α] c,
+      ⟨∃ c : SupportCondition β, c ∈ s ∧ (B, inr L.toNearLitter) ≤[α] c,
         fun _ => π.completeNearLitterMap B L.toNearLitter⟩
     atomMap_dom_small := by
-      change Small ((fun a : Atom => (inl a, B)) ⁻¹'
+      change Small ((fun a : Atom => (B, inl a)) ⁻¹'
         {c : SupportCondition β | ∃ d : SupportCondition β, d ∈ s ∧ c ≤[α] d})
       refine' Small.preimage _ (reduction_small' α hs)
       intro a b h
       cases h
       rfl
     litterMap_dom_small := by
-      change Small ((fun L : Litter => (inr L.toNearLitter, B)) ⁻¹'
+      change Small ((fun L : Litter => (B, inr L.toNearLitter)) ⁻¹'
         {c : SupportCondition β | ∃ d : SupportCondition β, d ∈ s ∧ c ≤[α] d})
       refine' Small.preimage _ (reduction_small' α hs)
       intro a b h
@@ -171,9 +171,9 @@ noncomputable def constrainedAction (π : StructApprox β) (s : Set (SupportCond
 /-- An object like `ih_action` that can take two support conditions. -/
 noncomputable def ihsAction (π : StructApprox β) (c d : SupportCondition β) : StructAction β :=
   fun B =>
-  { atomMap := fun a => ⟨(inl a, B) ∈ transConstrained c d,
+  { atomMap := fun a => ⟨(B, inl a) ∈ transConstrained c d,
       fun _ => π.completeAtomMap B a⟩
-    litterMap := fun L => ⟨(inr L.toNearLitter, B) ∈ transConstrained c d,
+    litterMap := fun L => ⟨(B, inr L.toNearLitter) ∈ transConstrained c d,
       fun _ => π.completeNearLitterMap B L.toNearLitter⟩
     atomMap_dom_small :=
       Small.union (ihAction π.foaHypothesis B).atomMap_dom_small
@@ -186,7 +186,7 @@ noncomputable def ihsAction (π : StructApprox β) (c d : SupportCondition β) :
 theorem constrainedAction_atomMap {π : StructApprox β} {s : Set (SupportCondition β)} {hs : Small s}
     {B : ExtendedIndex β} {a : Atom} :
     (constrainedAction π s hs B).atomMap a =
-      ⟨∃ c : SupportCondition β, c ∈ s ∧ (inl a, B) ≤[α] c,
+      ⟨∃ c : SupportCondition β, c ∈ s ∧ (B, inl a) ≤[α] c,
         fun _ => completeAtomMap π B a⟩ :=
   rfl
 
@@ -194,7 +194,7 @@ theorem constrainedAction_atomMap {π : StructApprox β} {s : Set (SupportCondit
 theorem constrainedAction_litterMap {π : StructApprox β} {s : Set (SupportCondition β)}
     {hs : Small s} {B : ExtendedIndex β} {L : Litter} :
     (constrainedAction π s hs B).litterMap L =
-      ⟨∃ c : SupportCondition β, c ∈ s ∧ (inr L.toNearLitter, B) ≤[α] c,
+      ⟨∃ c : SupportCondition β, c ∈ s ∧ (B, inr L.toNearLitter) ≤[α] c,
         fun _ => π.completeNearLitterMap B L.toNearLitter⟩ :=
   rfl
 
@@ -202,7 +202,7 @@ theorem constrainedAction_litterMap {π : StructApprox β} {s : Set (SupportCond
 theorem ihsAction_atomMap {π : StructApprox β} {c d : SupportCondition β} {B : ExtendedIndex β}
     {a : Atom} :
     (ihsAction π c d B).atomMap a =
-      ⟨(inl a, B) ∈ transConstrained c d,
+      ⟨(B, inl a) ∈ transConstrained c d,
         fun _ => completeAtomMap π B a⟩ :=
   rfl
 
@@ -210,7 +210,7 @@ theorem ihsAction_atomMap {π : StructApprox β} {c d : SupportCondition β} {B 
 theorem ihsAction_litterMap {π : StructApprox β} {c d : SupportCondition β} {B : ExtendedIndex β}
     {L : Litter} :
     (ihsAction π c d B).litterMap L =
-      ⟨(inr L.toNearLitter, B) ∈ transConstrained c d,
+      ⟨(B, inr L.toNearLitter) ∈ transConstrained c d,
         fun _ => π.completeNearLitterMap B L.toNearLitter⟩ :=
   rfl
 
@@ -318,15 +318,14 @@ theorem transGen_constrains_of_mem_designatedSupport {A : ExtendedIndex β} {L :
     {h : InflexibleCoe L A} {γ : Iic α} {δ ε : Iio α} {hδ : (δ : Λ) < γ} {hε : (ε : Λ) < γ}
     (hδε : δ ≠ ε) {C : Path (h.δ : TypeIndex) γ} {t : Tangle δ} {d : SupportCondition h.δ}
     (hd₂ :
-      (inr (fuzz (Subtype.coe_injective.ne (Iio.coe_injective.ne hδε)) t).toNearLitter,
-          (C.cons (coe_lt hε)).cons (bot_lt_coe _)) ≤[α]
-        d)
-    (hd : (d.fst, (h.B.cons (coe_lt h.hδ)).comp d.snd) ≺[α] (inr L.toNearLitter, A))
-    {B : ExtendedIndex δ} {a : Atom} (hc : (inl a, B) ∈ (designatedSupport t).carrier) :
-    (inl a, (h.B.cons (coe_lt h.hδ)).comp ((C.cons (coe_lt hδ)).comp B)) <[α]
-      (inr L.toNearLitter, A) := by
+      ((C.cons (coe_lt hε)).cons (bot_lt_coe _),
+        inr (fuzz (Subtype.coe_injective.ne (Iio.coe_injective.ne hδε)) t).toNearLitter) ≤[α] d)
+    (hd : ((h.B.cons (coe_lt h.hδ)).comp d.fst, d.snd) ≺[α] (A, inr L.toNearLitter))
+    {B : ExtendedIndex δ} {a : Atom} (hc : (B, inl a) ∈ (designatedSupport t).carrier) :
+    ((h.B.cons (coe_lt h.hδ)).comp ((C.cons (coe_lt hδ)).comp B), inl a) <[α]
+      (A, inr L.toNearLitter) := by
   refine' Relation.TransGen.tail' _ hd
-  refine' reflTransGen_constrains_comp (c := (inl a, _)) (d := d) _ (h.B.cons <| coe_lt h.hδ)
+  refine' reflTransGen_constrains_comp (c := (_, inl a)) (d := d) _ (h.B.cons <| coe_lt h.hδ)
   refine' Relation.ReflTransGen.trans _ hd₂
   exact Relation.ReflTransGen.single (Constrains.fuzz hδ hε hδε C t _ hc)
 

--- a/ConNF/Foa/Properties/Injective.lean
+++ b/ConNF/Foa/Properties/Injective.lean
@@ -14,8 +14,8 @@ variable [Params.{u}] {α : Λ} [BasePositions] [Phase2Assumptions α] {β : Iic
   [FreedomOfActionHypothesis β] {π : StructApprox β}
 
 theorem atom_injective_extends {c d : SupportCondition β} (hcd : (ihsAction π c d).Lawful)
-    {a b : Atom} {A : ExtendedIndex β} (hac : (inl a, A) ∈ reflTransConstrained c d)
-    (hbc : (inl b, A) ∈ reflTransConstrained c d)
+    {a b : Atom} {A : ExtendedIndex β} (hac : (A, inl a) ∈ reflTransConstrained c d)
+    (hbc : (A, inl b) ∈ reflTransConstrained c d)
     (h : π.completeAtomMap A a = π.completeAtomMap A b) : a = b :=
   by
   by_cases ha : a ∈ (π A).atomPerm.domain <;> by_cases hb : b ∈ (π A).atomPerm.domain
@@ -54,18 +54,6 @@ structure _root_.ConNF.NearLitterPerm.Biexact (π π' : NearLitterPerm) (atoms :
   smul_eq_smul_litter : ∀ L ∈ litters, π • L = π' • L
   left_exact : ∀ L ∈ litters, ∀ a, InOut π a L → π • a = π' • a
   right_exact : ∀ L ∈ litters, ∀ a, InOut π' a L → π • a = π' • a
-
-@[simp]
-theorem xor'_elim_left {a b : Prop} (h : a) : Xor' a b ↔ ¬b := by unfold Xor'; tauto
-
-@[simp]
-theorem xor'_elim_right {a b : Prop} (h : b) : Xor' a b ↔ ¬a := by unfold Xor'; tauto
-
-@[simp]
-theorem xor'_elim_not_left {a b : Prop} (h : ¬a) : Xor' a b ↔ b := by unfold Xor'; tauto
-
-@[simp]
-theorem xor'_elim_not_right {a b : Prop} (h : ¬b) : Xor' a b ↔ a := by unfold Xor'; tauto
 
 theorem _root_.ConNF.NearLitterPerm.Biexact.atoms {π π' : NearLitterPerm} (s : Set Atom)
     (hs : ∀ a ∈ s, π • a = π' • a) : NearLitterPerm.Biexact π π' s ∅ :=
@@ -156,23 +144,23 @@ theorem isException_of_inOut {π : NearLitterPerm} {a : Atom} {L : Litter} :
 structure Biexact {β : Iio α} (π π' : StructPerm β) (c : SupportCondition β) : Prop where
   smul_eq_smul_atom :
     ∀ A : ExtendedIndex β,
-      ∀ a : Atom, (inl a, A) ≤[α] c → StructPerm.derivative A π • a = StructPerm.derivative A π' • a
+      ∀ a : Atom, (A, inl a) ≤[α] c → StructPerm.derivative A π • a = StructPerm.derivative A π' • a
   smul_eq_smul_litter :
     ∀ A : ExtendedIndex β,
       ∀ L : Litter,
-        (inr L.toNearLitter, A) ≤[α] c →
+        (A, inr L.toNearLitter) ≤[α] c →
           Flexible α L A → StructPerm.derivative A π • L = StructPerm.derivative A π' • L
   exact :
     ∀ A : ExtendedIndex β,
       ∀ L : Litter,
-        (inr L.toNearLitter, A) ≤[α] c →
+        (A, inr L.toNearLitter) ≤[α] c →
           StructPerm.derivative A π • L = StructPerm.derivative A π' • L →
             StructPerm.derivative A π • L.toNearLitter = StructPerm.derivative A π' • L.toNearLitter
 
 theorem Biexact.atoms {β : Iio α} {π π' : StructPerm β} {c : SupportCondition β}
     (h : Biexact π π' c) (A : ExtendedIndex β) :
     NearLitterPerm.Biexact (StructPerm.ofBot <| StructPerm.derivative A π)
-      (StructPerm.ofBot <| StructPerm.derivative A π') {a | (inl a, A) ≤[α] c} ∅ :=
+      (StructPerm.ofBot <| StructPerm.derivative A π') {a | (A, inl a) ≤[α] c} ∅ :=
   NearLitterPerm.Biexact.atoms _ (h.smul_eq_smul_atom A)
 
 theorem Biexact.constrains {β : Iio α} {π π' : StructPerm β} {c d : SupportCondition β}
@@ -199,8 +187,8 @@ theorem Biexact.smul_eq_smul {β : Iio α} {π π' : Allowable β} {c : SupportC
   · have :=
       ih _ (Constrains.nearLitter N (NearLitter.not_isLitter hL) A)
         (h.constrains (reflTransGen_nearLitter Relation.ReflTransGen.refl))
-    change (inr _, _) = (inr _, _) at this
-    simp only [Prod.mk.injEq, inr.injEq, and_true] at this
+    change (_, inr _) = (_, inr _) at this
+    simp only [Prod.mk.injEq, inr.injEq, true_and] at this
     refine' SetLike.coe_injective _
     refine' (NearLitterPerm.smul_nearLitter_eq_smul_symmDiff_smul _ _).trans _
     refine' Eq.trans _ (NearLitterPerm.smul_nearLitter_eq_smul_symmDiff_smul _ _).symm
@@ -208,16 +196,16 @@ theorem Biexact.smul_eq_smul {β : Iio α} {π π' : Allowable β} {c : SupportC
     ext a : 1
     constructor
     · rintro ⟨b, hb, rfl⟩
-      have : (inl _, _) = (inl _, _) :=
+      have : (_, inl _) = (_, inl _) :=
         ih _ (Constrains.symmDiff N b hb A)
           (h.constrains (Relation.ReflTransGen.single <| Constrains.symmDiff N b hb A))
-      simp only [Prod.mk.injEq, inl.injEq, and_true] at this
+      simp only [Prod.mk.injEq, inl.injEq, true_and] at this
       exact ⟨b, hb, this.symm⟩
     · rintro ⟨b, hb, rfl⟩
-      have : (inl _, _) = (inl _, _) :=
+      have : (_, inl _) = (_, inl _) :=
         ih _ (Constrains.symmDiff N b hb A)
           (h.constrains (Relation.ReflTransGen.single <| Constrains.symmDiff N b hb A))
-      simp only [Prod.mk.injEq, inl.injEq, and_true] at this
+      simp only [Prod.mk.injEq, inl.injEq, true_and] at this
       exact ⟨b, hb, this⟩
   obtain ⟨L, rfl⟩ := hL.exists_litter_eq
   suffices
@@ -253,7 +241,7 @@ theorem Biexact.smul_eq_smul {β : Iio α} {π π' : Allowable β} {c : SupportC
       Allowable.toStructPerm_derivative
         (show Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from B),
       StructPerm.derivative_derivative, StructPerm.derivative_derivative]
-    have := ih (c.fst, (B.cons <| coe_lt hδ).comp c.snd) ?_ ?_
+    have := ih ((B.cons <| coe_lt hδ).comp c.fst, c.snd) ?_ ?_
     · rw [StructPerm.smul_supportCondition_eq_iff]
       exact (StructPerm.smul_supportCondition_eq_iff.mp this).symm
     · exact Constrains.fuzz hδ hε hδε _ _ _ hc
@@ -277,9 +265,9 @@ theorem Biexact.smul_eq_smul {β : Iio α} {π π' : Allowable β} {c : SupportC
       Allowable.toStructPerm_derivative
         (show Path ((β : IicBot α) : TypeIndex) (γ : IicBot α) from B),
       StructPerm.derivative_apply, StructPerm.derivative_apply]
-    have := ih (inl a, B.cons <| bot_lt_coe _) ?_ ?_
-    · change (inl _, _) = (inl _, _) at this
-      simp only [Prod.mk.injEq, inl.injEq, and_true] at this
+    have := ih (B.cons <| bot_lt_coe _, inl a) ?_ ?_
+    · change (_, inl _) = (_, inl _) at this
+      simp only [Prod.mk.injEq, inl.injEq, true_and] at this
       exact this
     · exact Constrains.fuzz_bot hε _ _
     · refine' h.constrains (Relation.ReflTransGen.single _)
@@ -287,12 +275,12 @@ theorem Biexact.smul_eq_smul {β : Iio α} {π π' : Allowable β} {c : SupportC
 
 theorem Biexact.smul_eq_smul_nearLitter {β : Iio α} {π π' : Allowable β} {A : ExtendedIndex β}
     {N : NearLitter}
-    (h : Biexact (Allowable.toStructPerm π) (Allowable.toStructPerm π') (inr N, A)) :
+    (h : Biexact (Allowable.toStructPerm π) (Allowable.toStructPerm π') (A, inr N)) :
     StructPerm.derivative A (Allowable.toStructPerm π) • N =
     StructPerm.derivative A (Allowable.toStructPerm π') • N := by
-  have : (inr _, _) = (inr _, _) := h.smul_eq_smul
+  have : (_, inr _) = (_, inr _) := h.smul_eq_smul
   rw [Prod.mk.inj_iff] at this
-  exact inr_injective this.1
+  exact inr_injective this.2
 
 theorem mem_dom_of_exactlyApproximates {β : Iio α} {π₀ : StructApprox β} {π : StructPerm β}
     (hπ : π₀.ExactlyApproximates π) {A : ExtendedIndex β} {a : Atom} {L : Litter}
@@ -316,7 +304,7 @@ theorem constrainedAction_comp_mapFlexible (hπf : π.Free) {γ : Iio α} {s : S
   simp only [StructAction.comp_apply, constrainedAction_litterMap,
     foaHypothesis_nearLitterImage]
   rw [completeNearLitterMap_fst_eq]
-  obtain hL₃ | (⟨⟨hL₃⟩⟩ | ⟨⟨hL₃⟩⟩) := flexible_cases' _ L (A.comp B)
+  obtain hL₃ | (⟨⟨hL₃⟩⟩ | ⟨⟨hL₃⟩⟩) := flexible_cases' _ (A.comp B) L
   · rw [completeLitterMap_eq_of_flexible hL₃]
     refine' NearLitterApprox.flexibleCompletion_smul_flexible _ _ _ _ _ hL₂
     intro L' hL'
@@ -376,7 +364,7 @@ theorem completeLitterMap_inflexibleBot {A : ExtendedIndex β} {L : Litter}
 
 theorem completeLitterMap_inflexibleCoe (hπf : π.Free) {c d : SupportCondition β}
     (hcd : (ihsAction π c d).Lawful) {A : ExtendedIndex β} {L : Litter} (h : InflexibleCoe L A)
-    (hL : (inr L.toNearLitter, A) ∈ reflTransConstrained c d) :
+    (hL : (A, inr L.toNearLitter) ∈ reflTransConstrained c d) :
     InflexibleCoe (π.completeLitterMap A L) A := by
   rw [completeLitterMap_eq_of_inflexibleCoe h]
   obtain ⟨γ, δ, ε, hδ, hε, hδε, B, a, rfl, rfl⟩ := h
@@ -392,9 +380,9 @@ theorem completeLitterMap_inflexibleCoe (hπf : π.Free) {c d : SupportCondition
 
 theorem completeLitterMap_flexible' (hπf : π.Free) {c d : SupportCondition β}
     (hcd : (ihsAction π c d).Lawful) {A : ExtendedIndex β} {L : Litter}
-    (hL : (inr L.toNearLitter, A) ∈ reflTransConstrained c d)
+    (hL : (A, inr L.toNearLitter) ∈ reflTransConstrained c d)
     (h : Flexible α (π.completeLitterMap A L) A) : Flexible α L A := by
-  obtain h' | h' | h' := flexible_cases' β L A
+  obtain h' | h' | h' := flexible_cases' β A L
   · exact h'
   · have := completeLitterMap_inflexibleBot (π := π) h'.some
     rw [flexible_iff_not_inflexibleBot_inflexibleCoe] at h
@@ -405,16 +393,16 @@ theorem completeLitterMap_flexible' (hπf : π.Free) {c d : SupportCondition β}
 
 theorem completeLitterMap_flexible_iff (hπf : π.Free) {c d : SupportCondition β}
     (hcd : (ihsAction π c d).Lawful) {A : ExtendedIndex β} {L : Litter}
-    (hL : (inr L.toNearLitter, A) ∈ reflTransConstrained c d) :
+    (hL : (A, inr L.toNearLitter) ∈ reflTransConstrained c d) :
     Flexible α (π.completeLitterMap A L) A ↔ Flexible α L A :=
   ⟨completeLitterMap_flexible' hπf hcd hL, completeLitterMap_flexible hπf⟩
 
 theorem completeLitterMap_inflexibleBot' (hπf : π.Free) {c d : SupportCondition β}
     (hcd : (ihsAction π c d).Lawful) {A : ExtendedIndex β} {L : Litter}
-    (hL : (inr L.toNearLitter, A) ∈ reflTransConstrained c d)
+    (hL : (A, inr L.toNearLitter) ∈ reflTransConstrained c d)
     (h : InflexibleBot (π.completeLitterMap A L) A) : InflexibleBot L A := by
   refine' Nonempty.some _
-  obtain h' | h' | h' := flexible_cases' β L A
+  obtain h' | h' | h' := flexible_cases' β A L
   · have := completeLitterMap_flexible hπf h'
     rw [flexible_iff_not_inflexibleBot_inflexibleCoe] at this
     cases this.1.false h
@@ -424,7 +412,7 @@ theorem completeLitterMap_inflexibleBot' (hπf : π.Free) {c d : SupportConditio
 
 theorem completeLitterMap_inflexibleBot_iff (hπf : π.Free) {c d : SupportCondition β}
     (hcd : (ihsAction π c d).Lawful) {A : ExtendedIndex β} {L : Litter}
-    (hL : (inr L.toNearLitter, A) ∈ reflTransConstrained c d) :
+    (hL : (A, inr L.toNearLitter) ∈ reflTransConstrained c d) :
     Nonempty (InflexibleBot (π.completeLitterMap A L) A) ↔ Nonempty (InflexibleBot L A) :=
   ⟨fun ⟨h⟩ => ⟨completeLitterMap_inflexibleBot' hπf hcd hL h⟩, fun ⟨h⟩ =>
     ⟨completeLitterMap_inflexibleBot h⟩⟩
@@ -432,7 +420,7 @@ theorem completeLitterMap_inflexibleBot_iff (hπf : π.Free) {c d : SupportCondi
 theorem completeLitterMap_inflexibleCoe' (hπf : π.Free) {A : ExtendedIndex β} {L : Litter}
     (h : InflexibleCoe (π.completeLitterMap A L) A) : InflexibleCoe L A := by
   refine' Nonempty.some _
-  obtain h' | h' | h' := flexible_cases' β L A
+  obtain h' | h' | h' := flexible_cases' β A L
   · have := completeLitterMap_flexible hπf h'
     rw [flexible_iff_not_inflexibleBot_inflexibleCoe] at this
     cases this.2.false h
@@ -442,7 +430,7 @@ theorem completeLitterMap_inflexibleCoe' (hπf : π.Free) {A : ExtendedIndex β}
 
 theorem completeLitterMap_inflexibleCoe_iff (hπf : π.Free) {c d : SupportCondition β}
     (hcd : (ihsAction π c d).Lawful) {A : ExtendedIndex β} {L : Litter}
-    (hL : (inr L.toNearLitter, A) ∈ reflTransConstrained c d) :
+    (hL : (A, inr L.toNearLitter) ∈ reflTransConstrained c d) :
     Nonempty (InflexibleCoe (π.completeLitterMap A L) A) ↔ Nonempty (InflexibleCoe L A) :=
   ⟨fun ⟨h⟩ => ⟨completeLitterMap_inflexibleCoe' hπf h⟩, fun ⟨h⟩ =>
     ⟨completeLitterMap_inflexibleCoe hπf hcd h hL⟩⟩
@@ -454,7 +442,7 @@ theorem _root_.ConNF.StructPerm.derivative_fst {α : TypeIndex} (π : StructPerm
 
 theorem constrainedAction_coherent' (hπf : π.Free) {γ : Iio α} (A : Path (β : TypeIndex) γ)
     (N : ExtendedIndex γ × NearLitter) (s : Set (SupportCondition β)) (hs : Small s)
-    (hc : ∃ c : SupportCondition β, c ∈ s ∧ (inr N.2, A.comp N.1) ≤[α] c)
+    (hc : ∃ c : SupportCondition β, c ∈ s ∧ (A.comp N.1, inr N.2) ≤[α] c)
     (hπ : ((constrainedAction π s hs).comp A).Lawful) (ρ : Allowable γ)
     (h : (((constrainedAction π s hs).comp A).rc hπ).ExactlyApproximates
       (Allowable.toStructPerm ρ)) :
@@ -464,10 +452,10 @@ theorem constrainedAction_coherent' (hπf : π.Free) {γ : Iio α} (A : Path (β
   refine'
     WellFounded.induction
       (C := fun N : ExtendedIndex γ × NearLitter => (∃ c : SupportCondition β, c ∈ s ∧
-        Relation.ReflTransGen (Constrains α ↑β) (inr N.snd, Path.comp A N.fst) c) →
+        Relation.ReflTransGen (Constrains α ↑β) (A.comp N.fst, inr N.snd) c) →
         completeNearLitterMap π (Path.comp A N.fst) N.snd =
         StructPerm.derivative N.fst (Allowable.toStructPerm ρ) • N.snd)
-      (InvImage.wf (fun N => (inr N.2, N.1)) (WellFounded.transGen (constrains_wf α γ))) N _
+      (InvImage.wf (fun N => (N.1, inr N.2)) (WellFounded.transGen (constrains_wf α γ))) N _
   clear N
   rintro ⟨B, N⟩ ih ⟨c, hc₁, hc₂⟩
   dsimp only at *
@@ -505,7 +493,7 @@ theorem constrainedAction_coherent' (hπf : π.Free) {γ : Iio α} (A : Path (β
   have hc₂' := reflTransGen_nearLitter hc₂
   generalize hNL : N.fst = L
   rw [hNL] at hdom hc₂'
-  obtain hL | ⟨⟨hL⟩⟩ | ⟨⟨hL⟩⟩ := flexible_cases' (γ : Iic α) L B
+  obtain hL | ⟨⟨hL⟩⟩ | ⟨⟨hL⟩⟩ := flexible_cases' (γ : Iic α) B L
   · refine' Eq.trans _ ((h B).map_litter L _)
     · rw [StructAction.rc_smul_litter_eq]
       rw [NearLitterAction.flexibleLitterPerm_apply_eq]
@@ -573,7 +561,7 @@ theorem constrainedAction_coherent' (hπf : π.Free) {γ : Iio α} (A : Path (β
     refine' (designatedSupport t).supports _ _
     intro c hct
     rw [mul_smul, inv_smul_eq_iff]
-    obtain ⟨a | M, D⟩ := c
+    obtain ⟨D, a | M⟩ := c
     · refine StructPerm.smul_supportCondition_eq_iff.mpr ?_
       change inl _ = inl _
       simp only [inl.injEq]
@@ -609,8 +597,8 @@ theorem constrainedAction_coherent' (hπf : π.Free) {γ : Iio α} (A : Path (β
       constructor
       · intro E a ha
         have haN :
-          (inl a, (C.cons <| coe_lt hε).comp E) <[α]
-            (inr N.fst.toNearLitter, (C.cons <| coe_lt hζ).cons (bot_lt_coe _))
+          ((C.cons <| coe_lt hε).comp E, inl a) <[α]
+            ((C.cons <| coe_lt hζ).cons (bot_lt_coe _), inr N.fst.toNearLitter)
         · simp only [hNL]
           refine' Relation.TransGen.tail' _ (Constrains.fuzz hε hζ hεζ _ _ _ hct)
           exact reflTransGen_constrains_comp ha _
@@ -655,8 +643,8 @@ theorem constrainedAction_coherent' (hπf : π.Free) {γ : Iio α} (A : Path (β
           refine' Relation.TransGen.trans_right (reflTransGen_constrains_comp hL₁ _) _
           exact Relation.TransGen.single (Constrains.fuzz hε hζ hεζ _ _ _ hct)
         have hLN :
-          (inr L.toNearLitter, (C.cons <| coe_lt hε).comp E) <[α]
-            (inr N.fst.toNearLitter, (C.cons <| coe_lt hζ).cons (bot_lt_coe _))
+          ((C.cons <| coe_lt hε).comp E, inr L.toNearLitter) <[α]
+            ((C.cons <| coe_lt hζ).cons (bot_lt_coe _), inr N.fst.toNearLitter)
         · simp only [hNL]
           refine' Relation.TransGen.tail' _ (Constrains.fuzz hε hζ hεζ _ _ _ hct)
           exact reflTransGen_constrains_comp hL₁ _
@@ -685,8 +673,8 @@ theorem constrainedAction_coherent' (hπf : π.Free) {γ : Iio α} (A : Path (β
         · exact hL₂
       · intro E L hL₁ hL₂
         have hLN :
-          (inr L.toNearLitter, (C.cons <| coe_lt hε).comp E) <[α]
-            (inr N.fst.toNearLitter, (C.cons <| coe_lt hζ).cons (bot_lt_coe _))
+          ((C.cons <| coe_lt hε).comp E, inr L.toNearLitter) <[α]
+            ((C.cons <| coe_lt hζ).cons (bot_lt_coe _), inr N.fst.toNearLitter)
         · simp only [hNL]
           refine' Relation.TransGen.tail' _ (Constrains.fuzz hε hζ hεζ _ _ _ hct)
           exact reflTransGen_constrains_comp hL₁ _
@@ -727,7 +715,7 @@ This condition can only be applied for `γ < α` as we're dealing with lower all
 -/
 theorem constrainedAction_coherent (hπf : π.Free) {γ : Iio α} (A : Path (β : TypeIndex) γ)
     (B : ExtendedIndex γ) (N : NearLitter) (s : Set (SupportCondition β)) (hs : Small s)
-    (hc : ∃ c : SupportCondition β, c ∈ s ∧ (inr N, A.comp B) ≤[α] c)
+    (hc : ∃ c : SupportCondition β, c ∈ s ∧ (A.comp B, inr N) ≤[α] c)
     (hπ : ((constrainedAction π s hs).comp A).Lawful) (ρ : Allowable γ)
     (h : (((constrainedAction π s hs).comp A).rc hπ).ExactlyApproximates
       (Allowable.toStructPerm ρ)) :
@@ -739,7 +727,7 @@ The statement is here for symmetry.
 -/
 theorem constrainedAction_coherent_atom {γ : Iio α}
     (A : Path (β : TypeIndex) γ) (B : ExtendedIndex γ) (a : Atom) (s : Set (SupportCondition β))
-    (hs : Small s) (hc : ∃ c : SupportCondition β, c ∈ s ∧ (inl a, A.comp B) ≤[α] c)
+    (hs : Small s) (hc : ∃ c : SupportCondition β, c ∈ s ∧ (A.comp B, inl a) ≤[α] c)
     (hπ : ((constrainedAction π s hs).comp A).Lawful) (ρ : Allowable γ)
     (h : (((constrainedAction π s hs).comp A).rc hπ).ExactlyApproximates
       (Allowable.toStructPerm ρ)) :
@@ -751,7 +739,7 @@ theorem constrainedAction_coherent_atom {γ : Iio α}
 
 theorem ihsAction_coherent (hπf : π.Free) {γ : Iio α} (A : Path (β : TypeIndex) γ)
     (B : ExtendedIndex γ) (N : NearLitter) (c d : SupportCondition β)
-    (hc : (inr N, A.comp B) ∈ transConstrained c d) (hπ : ((ihsAction π c d).comp A).Lawful)
+    (hc : (A.comp B, inr N) ∈ transConstrained c d) (hπ : ((ihsAction π c d).comp A).Lawful)
     (ρ : Allowable γ) (h : (((ihsAction π c d).comp A).rc hπ).ExactlyApproximates
       (Allowable.toStructPerm ρ)) :
     completeNearLitterMap π (A.comp B) N =
@@ -769,7 +757,7 @@ theorem ihsAction_coherent (hπf : π.Free) {γ : Iio α} (A : Path (β : TypeIn
     rw [ihsAction_eq_constrainedAction]
 
 theorem ihsAction_coherent_atom {γ : Iio α} (A : Path (β : TypeIndex) γ)
-    (B : ExtendedIndex γ) (a : Atom) (c d : SupportCondition β) (hc : (inl a, A.comp B) <[α] c)
+    (B : ExtendedIndex γ) (a : Atom) (c d : SupportCondition β) (hc : (A.comp B, inl a) <[α] c)
     (hπ : ((ihsAction π c d).comp A).Lawful) (ρ : Allowable γ)
     (h : (((ihsAction π c d).comp A).rc hπ).ExactlyApproximates (Allowable.toStructPerm ρ)) :
     completeAtomMap π (A.comp B) a = StructPerm.derivative B (Allowable.toStructPerm ρ) • a := by
@@ -779,7 +767,7 @@ theorem ihsAction_coherent_atom {γ : Iio α} (A : Path (β : TypeIndex) γ)
   exact Or.inl hc
 
 theorem ihAction_coherent (hπf : π.Free) {γ : Iio α} (A : Path (β : TypeIndex) γ)
-    (B : ExtendedIndex γ) (N : NearLitter) (c : SupportCondition β) (hc : (inr N, A.comp B) <[α] c)
+    (B : ExtendedIndex γ) (N : NearLitter) (c : SupportCondition β) (hc : (A.comp B, inr N) <[α] c)
     (hπ : ((ihAction (π.foaHypothesis : Hypothesis c)).comp A).Lawful) (ρ : Allowable γ)
     (h : (((ihAction (π.foaHypothesis : Hypothesis c)).comp A).rc hπ).ExactlyApproximates
         (Allowable.toStructPerm ρ)) :
@@ -792,7 +780,7 @@ theorem ihAction_coherent (hπf : π.Free) {γ : Iio α} (A : Path (β : TypeInd
     rw [ihsAction_self]
 
 theorem ihAction_coherent_atom {γ : Iio α} (A : Path (β : TypeIndex) γ)
-    (B : ExtendedIndex γ) (a : Atom) (c : SupportCondition β) (hc : (inl a, A.comp B) <[α] c)
+    (B : ExtendedIndex γ) (a : Atom) (c : SupportCondition β) (hc : (A.comp B, inl a) <[α] c)
     (hπ : ((ihAction (π.foaHypothesis : Hypothesis c)).comp A).Lawful) (ρ : Allowable γ)
     (h :
       (((ihAction (π.foaHypothesis : Hypothesis c)).comp A).rc hπ).ExactlyApproximates
@@ -805,8 +793,8 @@ theorem ihAction_coherent_atom {γ : Iio α} (A : Path (β : TypeIndex) γ)
     rw [ihsAction_self]
 
 theorem ihAction_smul_tangle' (hπf : π.Free) (c d : SupportCondition β) (A : ExtendedIndex β)
-    (L : Litter) (hL₁ : (inr L.toNearLitter, A) ≤[α] c) (hL₂ : InflexibleCoe L A) (hlaw₁ hlaw₂) :
-    (ihAction (π.foaHypothesis : Hypothesis (inr L.toNearLitter, A))).hypothesisedAllowable hL₂
+    (L : Litter) (hL₁ : (A, inr L.toNearLitter) ≤[α] c) (hL₂ : InflexibleCoe L A) (hlaw₁ hlaw₂) :
+    (ihAction (π.foaHypothesis : Hypothesis (A, inr L.toNearLitter))).hypothesisedAllowable hL₂
           hlaw₁ (ihAction_comp_mapFlexible hπf _ _) •
         hL₂.t =
       (ihsAction π c d).hypothesisedAllowable hL₂ hlaw₂ (ihsAction_comp_mapFlexible hπf _ _ _) •
@@ -817,7 +805,7 @@ theorem ihAction_smul_tangle' (hπf : π.Free) (c d : SupportCondition β) (A : 
   intro e he
   rw [mul_smul, inv_smul_eq_iff]
   refine StructPerm.smul_supportCondition_eq_iff.mpr ?_
-  obtain ⟨a | N, C⟩ := e
+  obtain ⟨C, a | N⟩ := e
   · change inl _ = inl _
     simp only [inl.injEq]
     refine'
@@ -825,8 +813,8 @@ theorem ihAction_smul_tangle' (hπf : π.Free) (c d : SupportCondition β) (A : 
         (ihsAction_coherent_atom _ _ a c d _ hlaw₂ _
           ((ihsAction π c d).hypothesisedAllowable_exactlyApproximates _ _ _))
     have := ihAction_coherent_atom (π := π) (B.cons ?_) C a
-        (inr (Litter.toNearLitter (fuzz (coe_ne_coe.mpr <| coe_ne' hδε) t)),
-          Path.cons (Path.cons B (coe_lt hε)) (bot_lt_coe _))
+        (Path.cons (Path.cons B (coe_lt hε)) (bot_lt_coe _),
+          inr (Litter.toNearLitter (fuzz (coe_ne_coe.mpr <| coe_ne' hδε) t)))
         ?_ hlaw₁ _
         ((ihAction π.foaHypothesis).hypothesisedAllowable_exactlyApproximates
           ⟨γ, δ, ε, hδ, hε, hδε, B, t, rfl, rfl⟩ ?_ ?_)
@@ -840,8 +828,8 @@ theorem ihAction_smul_tangle' (hπf : π.Free) (c d : SupportCondition β) (A : 
         (ihsAction_coherent hπf _ _ N c d _ hlaw₂ _
           ((ihsAction π c d).hypothesisedAllowable_exactlyApproximates _ _ _))
     have := ihAction_coherent hπf (B.cons ?_) C N
-        (inr (Litter.toNearLitter (fuzz (coe_ne_coe.mpr <| coe_ne' hδε) t)),
-          Path.cons (Path.cons B (coe_lt hε)) (bot_lt_coe _))
+        (Path.cons (Path.cons B (coe_lt hε)) (bot_lt_coe _),
+          inr (Litter.toNearLitter (fuzz (coe_ne_coe.mpr <| coe_ne' hδε) t)))
         ?_ hlaw₁ _
         ((ihAction π.foaHypothesis).hypothesisedAllowable_exactlyApproximates
           ⟨γ, δ, ε, hδ, hε, hδε, B, t, rfl, rfl⟩ ?_ ?_)
@@ -850,9 +838,9 @@ theorem ihAction_smul_tangle' (hπf : π.Free) (c d : SupportCondition β) (A : 
     · exact Or.inl (Relation.TransGen.head' (Constrains.fuzz hδ hε hδε B t _ he) hL₁)
 
 theorem ihAction_smul_tangle (hπf : π.Free) (c d : SupportCondition β) (A : ExtendedIndex β)
-    (L : Litter) (hL₁ : (inr L.toNearLitter, A) ∈ reflTransConstrained c d)
+    (L : Litter) (hL₁ : (A, inr L.toNearLitter) ∈ reflTransConstrained c d)
     (hL₂ : InflexibleCoe L A) (hlaw₁ hlaw₂) :
-    (ihAction (π.foaHypothesis : Hypothesis (inr L.toNearLitter, A))).hypothesisedAllowable hL₂
+    (ihAction (π.foaHypothesis : Hypothesis (A, inr L.toNearLitter))).hypothesisedAllowable hL₂
           hlaw₁ (ihAction_comp_mapFlexible hπf _ _) •
         hL₂.t =
       (ihsAction π c d).hypothesisedAllowable hL₂ hlaw₂ (ihsAction_comp_mapFlexible hπf _ _ _) •
@@ -867,10 +855,10 @@ theorem ihAction_smul_tangle (hπf : π.Free) (c d : SupportCondition β) (A : E
 
 theorem litter_injective_extends (hπf : π.Free) {c d : SupportCondition β}
     (hcd : (ihsAction π c d).Lawful) {A : ExtendedIndex β} {L₁ L₂ : Litter}
-    (h₁ : (inr L₁.toNearLitter, A) ∈ reflTransConstrained c d)
-    (h₂ : (inr L₂.toNearLitter, A) ∈ reflTransConstrained c d)
+    (h₁ : (A, inr L₁.toNearLitter) ∈ reflTransConstrained c d)
+    (h₂ : (A, inr L₂.toNearLitter) ∈ reflTransConstrained c d)
     (h : completeLitterMap π A L₁ = completeLitterMap π A L₂) : L₁ = L₂ := by
-  obtain h₁' | h₁' | h₁' := flexible_cases' β L₁ A
+  obtain h₁' | h₁' | h₁' := flexible_cases' β A L₁
   · have h₂' : Flexible α L₂ A
     · have := completeLitterMap_flexible hπf h₁'
       rw [h] at this
@@ -1033,7 +1021,7 @@ theorem splitLt_wellFounded {α : Type _} {r : α → α → Prop} (hr : WellFou
 -- TODO: Clean this up. Proof comes from an old lemma.
 theorem completeAtomMap_mem_completeNearLitterMap_toNearLitter' (hπf : π.Free)
     {c d : SupportCondition β} (hcd : (ihsAction π c d).Lawful) {A : ExtendedIndex β} {a : Atom}
-    {L : Litter} (ha : a.1 = L) (hL : (inr L.toNearLitter, A) ∈ reflTransConstrained c d) :
+    {L : Litter} (ha : a.1 = L) (hL : (A, inr L.toNearLitter) ∈ reflTransConstrained c d) :
     π.completeAtomMap A a ∈ π.completeNearLitterMap A L.toNearLitter := by
   subst ha
   rw [completeNearLitterMap_eq]
@@ -1071,40 +1059,40 @@ theorem ihsAction_lawful_extends (hπf : π.Free) (c d : SupportCondition β)
   intro A
   have litter_map_injective :
     ∀ ⦃L₁ L₂ : Litter⦄,
-      (inr L₁.toNearLitter, A) ∈ transConstrained c d →
-      (inr L₂.toNearLitter, A) ∈ transConstrained c d →
+      (A, inr L₁.toNearLitter) ∈ transConstrained c d →
+      (A, inr L₂.toNearLitter) ∈ transConstrained c d →
       ((π.completeNearLitterMap A L₁.toNearLitter : Set Atom) ∩
         (π.completeNearLitterMap A L₂.toNearLitter : Set Atom)).Nonempty →
       L₁ = L₂ := by
     intro L₁ L₂ h₁ h₂ h₁₂
     have := eq_of_completeLitterMap_inter_nonempty h₁₂
     obtain h₁ | h₁ := h₁ <;> obtain h₂ | h₂ := h₂
-    · specialize hπ (inr L₁.toNearLitter, A) (inr L₂.toNearLitter, A) (SplitLt.left_split h₁ h₂)
+    · specialize hπ (A, inr L₁.toNearLitter) (A, inr L₂.toNearLitter) (SplitLt.left_split h₁ h₂)
       exact litter_injective_extends hπf hπ (Or.inl Relation.ReflTransGen.refl)
         (Or.inr Relation.ReflTransGen.refl) this
-    · specialize hπ (inr L₁.toNearLitter, A) d (SplitLt.left_lt h₁)
+    · specialize hπ (A, inr L₁.toNearLitter) d (SplitLt.left_lt h₁)
       exact litter_injective_extends hπf hπ
         (Or.inl Relation.ReflTransGen.refl) (Or.inr h₂.to_reflTransGen) this
-    · specialize hπ c (inr L₁.toNearLitter, A) (SplitLt.right_lt h₁)
+    · specialize hπ c (A, inr L₁.toNearLitter) (SplitLt.right_lt h₁)
       exact litter_injective_extends hπf hπ
         (Or.inr Relation.ReflTransGen.refl) (Or.inl h₂.to_reflTransGen) this
-    · specialize hπ (inr L₁.toNearLitter, A) (inr L₂.toNearLitter, A) (SplitLt.right_split h₁ h₂)
+    · specialize hπ (A, inr L₁.toNearLitter) (A, inr L₂.toNearLitter) (SplitLt.right_split h₁ h₂)
       exact litter_injective_extends hπf hπ (Or.inl Relation.ReflTransGen.refl)
         (Or.inr Relation.ReflTransGen.refl) this
   constructor
   · intro a b ha hb hab
     simp only [ihsAction_atomMap] at ha hb hab
     obtain ha | ha := ha <;> obtain hb | hb := hb
-    · specialize hπ (inl a, A) (inl b, A) (SplitLt.left_split ha hb)
+    · specialize hπ (A, inl a) (A, inl b) (SplitLt.left_split ha hb)
       exact atom_injective_extends hπ (Or.inl Relation.ReflTransGen.refl)
         (Or.inr Relation.ReflTransGen.refl) hab
-    · specialize hπ (inl a, A) d (SplitLt.left_lt ha)
+    · specialize hπ (A, inl a) d (SplitLt.left_lt ha)
       exact atom_injective_extends hπ
         (Or.inl Relation.ReflTransGen.refl) (Or.inr hb.to_reflTransGen) hab
-    · specialize hπ c (inl a, A) (SplitLt.right_lt ha)
+    · specialize hπ c (A, inl a) (SplitLt.right_lt ha)
       exact atom_injective_extends hπ
         (Or.inr Relation.ReflTransGen.refl) (Or.inl hb.to_reflTransGen) hab
-    · specialize hπ (inl a, A) (inl b, A) (SplitLt.right_split ha hb)
+    · specialize hπ (A, inl a) (A, inl b) (SplitLt.right_split ha hb)
       exact atom_injective_extends hπ (Or.inl Relation.ReflTransGen.refl)
         (Or.inr Relation.ReflTransGen.refl) hab
   · exact litter_map_injective
@@ -1112,16 +1100,16 @@ theorem ihsAction_lawful_extends (hπf : π.Free) (c d : SupportCondition β)
     simp only [ihsAction_atomMap, ihsAction_litterMap]
     have : π.completeAtomMap A a ∈ π.completeNearLitterMap A a.fst.toNearLitter :=by
       obtain ha | ha := ha <;> obtain hL | hL := hL
-      · specialize hπ (inl a, A) (inr L.toNearLitter, A) (SplitLt.left_split ha hL)
+      · specialize hπ (A, inl a) (A, inr L.toNearLitter) (SplitLt.left_split ha hL)
         exact completeAtomMap_mem_completeNearLitterMap_toNearLitter' hπf hπ rfl
           (fst_mem_refl_trans_constrained' (Or.inl Relation.ReflTransGen.refl))
-      · specialize hπ (inl a, A) d (SplitLt.left_lt ha)
+      · specialize hπ (A, inl a) d (SplitLt.left_lt ha)
         exact completeAtomMap_mem_completeNearLitterMap_toNearLitter' hπf hπ rfl
           (fst_mem_refl_trans_constrained' (Or.inl Relation.ReflTransGen.refl))
-      · specialize hπ c (inl a, A) (SplitLt.right_lt ha)
+      · specialize hπ c (A, inl a) (SplitLt.right_lt ha)
         exact completeAtomMap_mem_completeNearLitterMap_toNearLitter' hπf hπ rfl
           (fst_mem_refl_trans_constrained' (Or.inr Relation.ReflTransGen.refl))
-      · specialize hπ (inl a, A) (inr L.toNearLitter, A) (SplitLt.right_split ha hL)
+      · specialize hπ (A, inl a) (A, inr L.toNearLitter) (SplitLt.right_split ha hL)
         exact
           completeAtomMap_mem_completeNearLitterMap_toNearLitter' hπf hπ rfl
             (fst_mem_refl_trans_constrained' (Or.inl Relation.ReflTransGen.refl))
@@ -1150,14 +1138,14 @@ We now establish a number of key consequences of `ihs_action_lawful`, such as in
 /-- The complete atom map is injective. -/
 theorem completeAtomMap_injective (hπf : π.Free) (A : ExtendedIndex β) :
     Injective (π.completeAtomMap A) := fun a b =>
-  atom_injective_extends (ihsAction_lawful hπf (inl a, A) (inl b, A))
+  atom_injective_extends (ihsAction_lawful hπf (A, inl a) (A, inl b))
     (Or.inl Relation.ReflTransGen.refl) (Or.inr Relation.ReflTransGen.refl)
 
 /-- The complete litter map is injective. -/
 theorem completeLitterMap_injective (hπf : π.Free) (A : ExtendedIndex β) :
     Injective (π.completeLitterMap A) := fun L₁ L₂ =>
   litter_injective_extends hπf
-    (ihsAction_lawful hπf (inr L₁.toNearLitter, A) (inr L₂.toNearLitter, A))
+    (ihsAction_lawful hπf (A, inr L₁.toNearLitter) (A, inr L₂.toNearLitter))
     (Or.inl Relation.ReflTransGen.refl) (Or.inr Relation.ReflTransGen.refl)
 
 /-- Atoms inside litters are mapped inside the corresponding image near-litter. -/
@@ -1165,7 +1153,7 @@ theorem completeAtomMap_mem_completeNearLitterMap_toNearLitter (hπf : π.Free) 
     {a : Atom} {L : Litter} :
     π.completeAtomMap A a ∈ π.completeNearLitterMap A L.toNearLitter ↔ a.1 = L := by
   have := completeAtomMap_mem_completeNearLitterMap_toNearLitter' hπf
-    (ihsAction_lawful hπf (inl a, A) (inl a, A)) rfl
+    (ihsAction_lawful hπf (A, inl a) (A, inl a)) rfl
     (fst_mem_refl_trans_constrained' (Or.inl Relation.ReflTransGen.refl))
   constructor
   · intro h

--- a/ConNF/Foa/Properties/Injective.lean
+++ b/ConNF/Foa/Properties/Injective.lean
@@ -188,7 +188,7 @@ theorem Biexact.smul_eq_smul {β : Iio α} {π π' : Allowable β} {c : SupportC
     (constrains_wf α β) c _
   clear c
   intro c ih h
-  obtain ⟨a | N, A⟩ := c <;> refine StructPerm.smul_supportCondition_eq_iff.mpr ?_
+  obtain ⟨A, a | N⟩ := c <;> refine StructPerm.smul_supportCondition_eq_iff.mpr ?_
   · change inl _ = inl _
     simp only [inl.injEq]
     exact h.smul_eq_smul_atom A a Relation.ReflTransGen.refl

--- a/ConNF/Foa/Properties/Surjective.lean
+++ b/ConNF/Foa/Properties/Surjective.lean
@@ -49,32 +49,32 @@ theorem completeAtomMap_surjective_extends (A : ExtendedIndex β) (a : Atom)
 
 noncomputable def completeSupportConditionMap (π : StructApprox β) :
     SupportCondition β → SupportCondition β
-  | (inl a, B) => (inl (π.completeAtomMap B a), B)
-  | (inr N, B) => (inr (π.completeNearLitterMap B N), B)
+  | (B, inl a) => (B, inl (π.completeAtomMap B a))
+  | (B, inr N) => (B, inr (π.completeNearLitterMap B N))
 
 @[simp]
 theorem completeSupportConditionMap_atom_eq {π : StructApprox β} {a : Atom} {B : ExtendedIndex β} :
-    π.completeSupportConditionMap (inl a, B) = (inl (π.completeAtomMap B a), B) :=
+    π.completeSupportConditionMap (B, inl a) = (B, inl (π.completeAtomMap B a)) :=
   rfl
 
 @[simp]
 theorem completeSupportConditionMap_nearLitter_eq {π : StructApprox β} {N : NearLitter}
     {B : ExtendedIndex β} :
-    π.completeSupportConditionMap (inr N, B) = (inr (π.completeNearLitterMap B N), B) :=
+    π.completeSupportConditionMap (B, inr N) = (B, inr (π.completeNearLitterMap B N)) :=
   rfl
 
 theorem completeSupportConditionMap_injective (hπf : π.Free) :
     Injective π.completeSupportConditionMap := by
-  rintro ⟨a₁ | N₁, B₁⟩ ⟨a₂ | N₂, B₂⟩ h <;>
+  rintro ⟨B₁, a₁ | N₁⟩ ⟨B₂, a₂ | N₂⟩ h <;>
     rw [Prod.ext_iff] at h <;>
     simp only [completeSupportConditionMap_atom_eq,
       completeSupportConditionMap_nearLitter_eq,
-      inl.injEq, inr.injEq, false_and] at h
-  · cases h.2
-    cases completeAtomMap_injective hπf B₁ h.1
+      inl.injEq, inr.injEq, and_false] at h
+  · cases h.1
+    cases completeAtomMap_injective hπf B₁ h.2
     rfl
-  · cases h.2
-    cases completeNearLitterMap_injective hπf B₁ h.1
+  · cases h.1
+    cases completeNearLitterMap_injective hπf B₁ h.2
     rfl
 
 def preimageConstrained (π : StructApprox β) (c : SupportCondition β) : Set (SupportCondition β) :=
@@ -115,7 +115,7 @@ theorem Relation.reflTransGen_of_eq {α : Type _} {r : α → α → Prop} {x y 
 
 theorem preimageAction_coherent (hπf : π.Free) {γ : Iio α} (A : Path (β : TypeIndex) γ)
     (B : ExtendedIndex γ) (N : NearLitter) (c : SupportCondition β)
-    (hc : (inr (π.completeNearLitterMap (A.comp B) N), A.comp B) ≺[α] c) (ρ : Allowable γ)
+    (hc : (A.comp B, inr (π.completeNearLitterMap (A.comp B) N)) ≺[α] c) (ρ : Allowable γ)
     (h : (((preimageAction hπf c).comp A).rc
       ((preimageAction_lawful hπf).comp _)).ExactlyApproximates (Allowable.toStructPerm ρ)) :
     completeNearLitterMap π (A.comp B) N =
@@ -127,7 +127,7 @@ theorem preimageAction_coherent (hπf : π.Free) {γ : Iio α} (A : Path (β : T
 
 theorem preimageAction_coherent_atom (hπf : π.Free) {γ : Iio α} (A : Path (β : TypeIndex) γ)
     (B : ExtendedIndex γ) (a : Atom) (c : SupportCondition β)
-    (hc : (inl (π.completeAtomMap (A.comp B) a), A.comp B) ≺[α] c) (ρ : Allowable γ)
+    (hc : (A.comp B, inl (π.completeAtomMap (A.comp B) a)) ≺[α] c) (ρ : Allowable γ)
     (h : (((preimageAction hπf c).comp A).rc
       ((preimageAction_lawful hπf).comp _)).ExactlyApproximates (Allowable.toStructPerm ρ)) :
     completeAtomMap π (A.comp B) a = StructPerm.derivative B (Allowable.toStructPerm ρ) • a := by
@@ -139,10 +139,10 @@ theorem preimageAction_coherent_atom (hπf : π.Free) {γ : Iio α} (A : Path (�
 -- I think that the `change` and `obtain` calls slow down proofs severely in Lean 4.
 -- TODO: Canonicalise uses of `<` to always be with respect to `TypeIndex`.
 theorem supports {β : Iio α} {π π' : Allowable β} {t : Tangle β}
-    (ha : ∀ a A, (inl a, A) ∈ designatedSupport t →
+    (ha : ∀ A a, (A, inl a) ∈ designatedSupport t →
       StructPerm.derivative A (Allowable.toStructPerm π) • a =
       StructPerm.derivative A (Allowable.toStructPerm π') • a)
-    (hN : ∀ N A, (inr N, A) ∈ designatedSupport t →
+    (hN : ∀ A N, (A, inr N) ∈ designatedSupport t →
       StructPerm.derivative A (Allowable.toStructPerm π) • N =
       StructPerm.derivative A (Allowable.toStructPerm π') • N) :
     π • t = π' • t := by
@@ -150,15 +150,14 @@ theorem supports {β : Iio α} {π π' : Allowable β} {t : Tangle β}
   refine' (designatedSupport t).supports _ _
   intro c hc
   rw [mul_smul, inv_smul_eq_iff]
-  change (_, c.2) = (_, c.2)
   refine StructPerm.smul_supportCondition_eq_iff.mpr ?_
   obtain ⟨A, a | N⟩ := c
   · change inl _ = inl _
     simp only [inl.injEq]
-    exact ha a A hc
+    exact ha A a hc
   · change inr _ = inr _
     simp only [inr.injEq]
-    exact hN N A hc
+    exact hN A N hc
 
 theorem _root_.ConNF.StructPerm.derivative_bot_smul_atom {α : TypeIndex} (π : StructPerm α)
     (A : ExtendedIndex α) (a : Atom) :
@@ -172,11 +171,11 @@ theorem _root_.ConNF.StructPerm.derivative_bot_smul_nearLitter {α : TypeIndex} 
 
 theorem completeLitterMap_surjective_extends (hπf : π.Free) (A : ExtendedIndex β) (L : Litter)
     (ha : ∀ (B : ExtendedIndex β) (a : Atom),
-      (inl a, B) ≺[α] (inr L.toNearLitter, A) → a ∈ range (π.completeAtomMap B))
+      (B, inl a) ≺[α] (A, inr L.toNearLitter) → a ∈ range (π.completeAtomMap B))
     (hN : ∀ (B : ExtendedIndex β) (N : NearLitter),
-      (inr N, B) ≺[α] (inr L.toNearLitter, A) → N ∈ range (π.completeNearLitterMap B)) :
+      (B, inr N) ≺[α] (A, inr L.toNearLitter) → N ∈ range (π.completeNearLitterMap B)) :
     L ∈ range (π.completeLitterMap A) := by
-  obtain h | ⟨⟨h⟩⟩ | ⟨⟨h⟩⟩ := flexible_cases' β L A
+  obtain h | ⟨⟨h⟩⟩ | ⟨⟨h⟩⟩ := flexible_cases' β A L
   · refine' ⟨(NearLitterApprox.flexibleCompletion α (π A) A).symm • L, _⟩
     rw [completeLitterMap_eq_of_flexible, NearLitterApprox.right_inv_litter]
     · rw [NearLitterApprox.flexibleCompletion_litterPerm_domain_free α (π A) A (hπf A)]
@@ -189,8 +188,8 @@ theorem completeLitterMap_surjective_extends (hπf : π.Free) (A : ExtendedIndex
   · obtain ⟨γ, δ, ε, hδ, hε, hδε, B, t, rfl, rfl⟩ := h
     refine' ⟨fuzz (coe_ne_coe.mpr <| coe_ne' hδε)
       (((preimageAction hπf
-            (inr (fuzz (coe_ne_coe.mpr <| coe_ne' hδε) t).toNearLitter,
-              (B.cons (coe_lt hε)).cons (bot_lt_coe _))).hypothesisedAllowable
+            ((B.cons (coe_lt hε)).cons (bot_lt_coe _),
+              inr (fuzz (coe_ne_coe.mpr <| coe_ne' hδε) t).toNearLitter)).hypothesisedAllowable
           ⟨γ, δ, ε, hδ, hε, hδε, B, t, rfl, rfl⟩
           ((preimageAction_lawful hπf).comp _) (preimageAction_comp_mapFlexible _))⁻¹ • t), _⟩
     rw [completeLitterMap_eq_of_inflexibleCoe ⟨γ, δ, ε, hδ, hε, hδε, B, _, rfl, rfl⟩
@@ -199,14 +198,14 @@ theorem completeLitterMap_surjective_extends (hπf : π.Free) (A : ExtendedIndex
     dsimp only
     rw [smul_eq_iff_eq_inv_smul]
     refine supports (t := t) ?_ ?_
-    · intros a A hc
+    · intros A a hc
       have hac := Constrains.fuzz hδ hε hδε B t _ hc
       specialize ha _ a hac
       obtain ⟨b, ha⟩ := ha
       have : (StructPerm.derivative A
         (Allowable.toStructPerm ((preimageAction hπf
-            (inr (fuzz (coe_ne_coe.mpr <| coe_ne' hδε) t).toNearLitter,
-              (B.cons (coe_lt hε)).cons (bot_lt_coe _))).hypothesisedAllowable
+            ((B.cons (coe_lt hε)).cons (bot_lt_coe _),
+              inr (fuzz (coe_ne_coe.mpr <| coe_ne' hδε) t).toNearLitter)).hypothesisedAllowable
               ⟨γ, δ, ε, hδ, hε, hδε, B, t, rfl, rfl⟩ ((preimageAction_lawful hπf).comp _)
               (preimageAction_comp_mapFlexible _))))⁻¹ • a = b
       · rw [inv_smul_eq_iff, ← ha]
@@ -227,18 +226,18 @@ theorem completeLitterMap_surjective_extends (hπf : π.Free) (A : ExtendedIndex
         refine' Relation.TransGen.tail' _
           (Constrains.fuzz hδ hε hδε B _ _ (smul_mem_designatedSupport hc _))
         refine' Relation.reflTransGen_of_eq _
-        refine' Prod.ext _ rfl
+        refine' Prod.ext rfl _
         change inl _ = inl _
         simp only [← this, ne_eq, StructPerm.derivative_bot, StructPerm.toBot_inv_smul, map_inv,
           StructPerm.inv_apply]
-    · intros N A hc
+    · intros A N hc
       have hNc := Constrains.fuzz hδ hε hδε B t _ hc
       specialize hN _ N hNc
       obtain ⟨N', hN⟩ := hN
       have : (StructPerm.derivative A
         (Allowable.toStructPerm ((preimageAction hπf
-          (inr (fuzz (coe_ne_coe.mpr <| coe_ne' hδε) t).toNearLitter,
-            (B.cons (coe_lt hε)).cons (bot_lt_coe _))).hypothesisedAllowable
+          ((B.cons (coe_lt hε)).cons (bot_lt_coe _),
+            inr (fuzz (coe_ne_coe.mpr <| coe_ne' hδε) t).toNearLitter)).hypothesisedAllowable
               ⟨γ, δ, ε, hδ, hε, hδε, B, t, rfl, rfl⟩ ((preimageAction_lawful hπf).comp _)
               (preimageAction_comp_mapFlexible _))))⁻¹ • N = N'
       · rw [inv_smul_eq_iff, ← hN]
@@ -259,7 +258,7 @@ theorem completeLitterMap_surjective_extends (hπf : π.Free) (A : ExtendedIndex
         refine' Relation.TransGen.tail' _
           (Constrains.fuzz hδ hε hδε B _ _ (smul_mem_designatedSupport hc _))
         refine' Relation.reflTransGen_of_eq _
-        refine' Prod.ext _ rfl
+        refine' Prod.ext rfl _
         change inr _ = inr _
         simp only [← this, ne_eq, StructPerm.derivative_bot, StructPerm.toBot_inv_smul, map_inv,
           StructPerm.inv_apply]
@@ -322,8 +321,8 @@ theorem completeNearLitterMap_surjective_extends (hπf : π.Free) (A : ExtendedI
 variable (π)
 
 def CompleteMapSurjectiveAt : SupportCondition β → Prop
-  | (inl a, A) => a ∈ range (π.completeAtomMap A)
-  | (inr N, A) => N ∈ range (π.completeNearLitterMap A)
+  | (A, inl a) => a ∈ range (π.completeAtomMap A)
+  | (A, inr N) => N ∈ range (π.completeNearLitterMap A)
 
 variable {π}
 
@@ -332,7 +331,7 @@ theorem completeMap_surjective_extends (hπf : π.Free) (c : SupportCondition β
     π.CompleteMapSurjectiveAt c := by
   obtain ⟨A, a | N⟩ := c
   · refine' completeAtomMap_surjective_extends A a _
-    obtain ⟨N, hN⟩ := hc (inr a.1.toNearLitter, A) (Relation.TransGen.single <| Constrains.atom a A)
+    obtain ⟨N, hN⟩ := hc (A, inr a.1.toNearLitter) (Relation.TransGen.single <| Constrains.atom a A)
     refine' ⟨N.1, _⟩
     apply_fun Sigma.fst at hN
     simp only [Litter.toNearLitter_fst, completeNearLitterMap_fst_eq'] at hN
@@ -340,21 +339,21 @@ theorem completeMap_surjective_extends (hπf : π.Free) (c : SupportCondition β
   · refine' completeNearLitterMap_surjective_extends hπf A N _ _
     · refine' completeLitterMap_surjective_extends hπf A N.1 _ _
       · intro B a h
-        exact hc (inl a, B) (transGen_nearLitter <| Relation.TransGen.single h)
+        exact hc (B, inl a) (transGen_nearLitter <| Relation.TransGen.single h)
       · intro B N h
-        exact hc (inr N, B) (transGen_nearLitter <| Relation.TransGen.single h)
+        exact hc (B, inr N) (transGen_nearLitter <| Relation.TransGen.single h)
     · intro a h
-      exact hc (inl a, A) (Relation.TransGen.single <| Constrains.symmDiff N a h A)
+      exact hc (A, inl a) (Relation.TransGen.single <| Constrains.symmDiff N a h A)
 
 theorem completeMapSurjectiveAtAll (hπf : π.Free) (c : SupportCondition β) :
     π.CompleteMapSurjectiveAt c :=
   WellFounded.induction (trans_constrains_wf α β) c (completeMap_surjective_extends hπf)
 
 theorem completeAtomMap_surjective (hπf : π.Free) (A : ExtendedIndex β) :
-    Surjective (π.completeAtomMap A) := fun a => completeMapSurjectiveAtAll hπf (inl a, A)
+    Surjective (π.completeAtomMap A) := fun a => completeMapSurjectiveAtAll hπf (A, inl a)
 
 theorem completeNearLitterMap_surjective (hπf : π.Free) (A : ExtendedIndex β) :
-    Surjective (π.completeNearLitterMap A) := fun N => completeMapSurjectiveAtAll hπf (inr N, A)
+    Surjective (π.completeNearLitterMap A) := fun N => completeMapSurjectiveAtAll hπf (A, inr N)
 
 theorem completeLitterMap_surjective (hπf : π.Free) (A : ExtendedIndex β) :
     Surjective (π.completeLitterMap A) := by

--- a/ConNF/Foa/Properties/Surjective.lean
+++ b/ConNF/Foa/Properties/Surjective.lean
@@ -152,7 +152,7 @@ theorem supports {β : Iio α} {π π' : Allowable β} {t : Tangle β}
   rw [mul_smul, inv_smul_eq_iff]
   change (_, c.2) = (_, c.2)
   refine StructPerm.smul_supportCondition_eq_iff.mpr ?_
-  obtain ⟨a | N, A⟩ := c
+  obtain ⟨A, a | N⟩ := c
   · change inl _ = inl _
     simp only [inl.injEq]
     exact ha a A hc
@@ -330,7 +330,7 @@ variable {π}
 theorem completeMap_surjective_extends (hπf : π.Free) (c : SupportCondition β)
     (hc : ∀ d : SupportCondition β, d <[α] c → π.CompleteMapSurjectiveAt d) :
     π.CompleteMapSurjectiveAt c := by
-  obtain ⟨a | N, A⟩ := c
+  obtain ⟨A, a | N⟩ := c
   · refine' completeAtomMap_surjective_extends A a _
     obtain ⟨N, hN⟩ := hc (inr a.1.toNearLitter, A) (Relation.TransGen.single <| Constrains.atom a A)
     refine' ⟨N.1, _⟩

--- a/ConNF/Foa/Result.lean
+++ b/ConNF/Foa/Result.lean
@@ -160,9 +160,9 @@ theorem ConNF.StructApprox.extracted_2
   refine' congr_arg _ _
   simp only
   refine supports (t := t) ?_ ?_
-  · intros a B ha
+  · intros B a ha
     have := ihAction_coherent_atom (π := π) (A.cons _) B a
-      (inr (fuzz (show (δ : TypeIndex) ≠ ε from ?_) t).toNearLitter, _)
+      (_, inr (fuzz (show (δ : TypeIndex) ≠ ε from ?_) t).toNearLitter)
       (Relation.TransGen.single <| Constrains.fuzz ?_ ?_ ?_ _ t _ ha)
       ((ihAction_lawful hπf _).comp _) ?_ ?_
     exact this.symm.trans (congr_arg (fun π => π • a) (hρ δ hδ B)).symm
@@ -175,9 +175,9 @@ theorem ConNF.StructApprox.extracted_2
       cases hδε rfl
     · exact (ihAction π.foaHypothesis).hypothesisedAllowable_exactlyApproximates
         ⟨γ, δ, ε, _, _, _, _, t, rfl, rfl⟩ _ _
-  · intros N B hN
+  · intros B N hN
     have := ihAction_coherent hπf (A.cons _) B N
-      (inr (fuzz (show (δ : TypeIndex) ≠ ε from ?_) t).toNearLitter, _)
+      (_, inr (fuzz (show (δ : TypeIndex) ≠ ε from ?_) t).toNearLitter)
       (Relation.TransGen.single <| Constrains.fuzz ?_ ?_ ?_ _ t _ hN)
       ((ihAction_lawful hπf _).comp _) ?_ ?_
     rw [← completeNearLitterPerm_smul_nearLitter hπf] at this

--- a/ConNF/Fuzz/Hypotheses.lean
+++ b/ConNF/Fuzz/Hypotheses.lean
@@ -98,9 +98,9 @@ class TypedObjects where
   contains only this near-litter. -/
   typedNearLitter : NearLitter ↪ Tangle α
   smul_typedNearLitter :
-    ∀ (π : Allowable α) (N : NearLitter),
-    π • typedNearLitter N =
-    typedNearLitter ((Allowable.toStructPerm π) (Quiver.Hom.toPath <| bot_lt_coe α) • N)
+    ∀ (ρ : Allowable α) (N : NearLitter),
+    ρ • typedNearLitter N =
+    typedNearLitter ((Allowable.toStructPerm ρ) (Quiver.Hom.toPath <| bot_lt_coe α) • N)
 
 export TypedObjects (typedAtom typedNearLitter)
 
@@ -111,9 +111,9 @@ variable [TypedObjects α]
 
 /-- The action of allowable permutations on tangles commutes with the `typedNearLitter` function
 mapping near-litters to typed near-litters. This can be seen by representing tangles as codes. -/
-theorem smul_typedNearLitter (π : Allowable α) (N : NearLitter) :
-    (π • typedNearLitter N : Tangle α) =
-    typedNearLitter ((Allowable.toStructPerm π) (Quiver.Hom.toPath <| bot_lt_coe α) • N) :=
+theorem smul_typedNearLitter (ρ : Allowable α) (N : NearLitter) :
+    (ρ • typedNearLitter N : Tangle α) =
+    typedNearLitter ((Allowable.toStructPerm ρ) (Quiver.Hom.toPath <| bot_lt_coe α) • N) :=
   TypedObjects.smul_typedNearLitter _ _
 
 end Allowable
@@ -184,12 +184,12 @@ noncomputable instance Bot.tangleData : TangleData ⊥
   allowableToStructPerm := StructPerm.toBotIso.toMonoidHom
   allowableAction := inferInstance
   designatedSupport a :=
-    { carrier := {(Sum.inl a, Quiver.Path.nil)}
+    { carrier := {(Quiver.Path.nil, Sum.inl a)}
       supports := fun π => by
         simp only [mem_singleton_iff, forall_eq]
         intro h
-        change (Sum.inl _, _) = (_, _) at h
-        simp only [MulEquiv.coe_toMonoidHom, Prod.mk.injEq, Sum.inl.injEq, and_true] at h
+        change (_, Sum.inl _) = (_, Sum.inl _) at h
+        simp only [MulEquiv.coe_toMonoidHom, Prod.mk.injEq, Sum.inl.injEq, true_and] at h
         exact h
       small := small_singleton _ }
 

--- a/ConNF/NewTangle/Tangle.lean
+++ b/ConNF/NewTangle/Tangle.lean
@@ -448,10 +448,10 @@ theorem _root_.ConNF.SemiallowablePerm.coe_apply_bot (ρ : SemiallowablePerm α)
 This is called a *typed near litter*. -/
 def newTypedNearLitter (N : NearLitter) : NewTangle α :=
   ⟨intro (show Set (Tangle (⊥ : IioBot α)) from N.2.1) <| Code.isEven_bot _,
-    ⟨⟨{(Sum.inr N, default)}, small_singleton _, fun π h => by
+    ⟨⟨{(Quiver.Hom.toPath (bot_lt_coe _), Sum.inr N)}, small_singleton _, fun π h => by
         simp only [smul_intro]
         congr 1
-        have : Sum.inr _ = _ := congr_arg Prod.fst (h rfl)
+        have : Sum.inr _ = _ := congr_arg Prod.snd (h rfl)
         simp only [AllowablePerm.coeHom_apply, Sum.inr.injEq] at this
         apply_fun SetLike.coe at this
         refine Eq.trans ?_ this

--- a/ConNF/Structural/Support.lean
+++ b/ConNF/Structural/Support.lean
@@ -22,24 +22,22 @@ namespace ConNF
 
 variable [Params.{u}] {α : TypeIndex}
 
--- TODO: Swap the elements of the following product type to align with codes and the new
--- calling convention.
-/-- A *support condition* is an atom or a near-litter together with an extended type index.
+/-- A *support condition* is an extended type index together with an atom or a near-litter.
 This represents an object in the base type (the atom or near-litter) together with the path
 detailing how we descend from type `α` to type `⊥` by looking at elements of elements and so on
 in the model. -/
 def SupportCondition (α : TypeIndex) : Type u :=
-  (Atom ⊕ NearLitter) × ExtendedIndex α
+  ExtendedIndex α × (Atom ⊕ NearLitter)
 
 noncomputable instance : Inhabited (SupportCondition α) :=
-⟨Sum.inl default, default⟩
+⟨default, Sum.inl default⟩
 
 /-- There are `μ` support conditions. -/
 @[simp]
 theorem mk_supportCondition (α : TypeIndex) : #(SupportCondition α) = #μ := by
   simp only [SupportCondition, mk_prod, mk_sum, mk_atom, lift_id, mk_nearLitter]
   rw [add_eq_left (κ_isRegular.aleph0_le.trans κ_le_μ) le_rfl]
-  exact mul_eq_left (κ_isRegular.aleph0_le.trans κ_le_μ)
+  exact mul_eq_right (κ_isRegular.aleph0_le.trans κ_le_μ)
     (le_trans (mk_extendedIndex α) <| le_of_lt <| lt_trans Λ_lt_κ κ_lt_μ) (mk_ne_zero _)
 
 namespace StructPerm
@@ -48,33 +46,33 @@ namespace StructPerm
 condition. -/
 instance : MulAction (StructPerm α) (SupportCondition α)
     where
-  smul π c := (π c.snd • c.fst, c.snd)
-  one_smul := by rintro ⟨a | N, A⟩ <;> rfl
-  mul_smul _ _ := by rintro ⟨a | N, A⟩ <;> rfl
+  smul π c := (c.fst, π c.fst • c.snd)
+  one_smul := by rintro ⟨A, a | N⟩ <;> rfl
+  mul_smul _ _ := by rintro ⟨A, a | N⟩ <;> rfl
 
 instance : MulAction NearLitterPerm (SupportCondition ⊥)
     where
-  smul π c := (π • c.fst, c.snd)
-  one_smul := by rintro ⟨a | N, A⟩ <;> rfl
-  mul_smul _ _ := by rintro ⟨a | N, A⟩ <;> rfl
+  smul π c := (c.fst, π • c.snd)
+  one_smul := by rintro ⟨A, a | N⟩ <;> rfl
+  mul_smul _ _ := by rintro ⟨A, a | N⟩ <;> rfl
 
 theorem smul_supportCondition {π : StructPerm α} {c : SupportCondition α} :
-    π • c = (π c.snd • c.fst, c.snd) :=
+    π • c = (c.fst, π c.fst • c.snd) :=
   rfl
 
 @[simp]
 theorem smul_supportCondition_eq_iff {π π' : StructPerm α} {c : SupportCondition α} :
-    π • c = π' • c ↔ π c.snd • c.fst = π' c.snd • c.fst := by
+    π • c = π' • c ↔ π c.fst • c.snd = π' c.fst • c.snd := by
   rw [Prod.ext_iff]
-  simp only [smul_supportCondition, and_true]
+  simp only [smul_supportCondition, true_and]
 
 @[simp]
 theorem smul_supportCondition_eq_iff' {π π' : StructPerm α}
     {x y : Atom ⊕ NearLitter} {A : ExtendedIndex α} :
-    π • (show SupportCondition α from (x, A)) = π' • (show SupportCondition α from (y, A)) ↔
+    π • (show SupportCondition α from (A, x)) = π' • (show SupportCondition α from (A, y)) ↔
     π A • x = π' A • y := by
   rw [Prod.ext_iff]
-  simp only [smul_supportCondition, and_true]
+  simp only [smul_supportCondition, true_and]
 
 -- The following attributes help with simplifications involving support conditions.
 attribute [simp] Sum.inl.injEq

--- a/Naming.md
+++ b/Naming.md
@@ -30,7 +30,8 @@ Follow the [mathlib4 naming convention](https://github.com/leanprover-community/
 | Support conditions                       | `c₁, c₂`        |
 | Codes                                    | `c, d`          |
 | Paths of type indices                    | `A, B`          |
-| Near-litter or structural actions        | `χ, χ'`         |
+| Near-litter or structural actions        | `ψ, ψ'`         |
 | Near-litter or structural approximations | `φ, φ'`         |
 | Near-litter or structural permutations   | `π, π'`         |
 | Allowable or semiallowable permutations  | `ρ, ρ'`         |
+| Coding functions                         | `χ, χ'`         |

--- a/TODO.md
+++ b/TODO.md
@@ -8,3 +8,7 @@
 - Move all the things of the form `_root_.*`
 - Clarify that `@[simp]` lemmas normalise casts between permutation types to be visible to help with applying lemmas. (Change them to coercions, and then we won't need this maybe?)
 - Remove instance names.
+- Rename `AllowablePerm` to `NewAllowable`; rename all of the `Allowable`/`NearLitterPerm`/`StructPerm` objects?
+- Remove mathport comments.
+- Remove double line breaks.
+- Reformat lines containing only `by`.


### PR DESCRIPTION
This would pull support conditions in line with the new calling convention for things that take paths and base-type objects: the path always comes first.